### PR TITLE
Account for real Xbox 360 .gpd files

### DIFF
--- a/source/Providers/Xenia/GPDResolver.cs
+++ b/source/Providers/Xenia/GPDResolver.cs
@@ -114,6 +114,11 @@ namespace PlayniteAchievements.Providers.Xenia
                 {
                     case 1: // Achievement Data
 
+                        // Some "Achievement" entries from a real xbox 360 gpd have too little data (Probably not real achievements)
+                        // and can cause a crash when reading the data in
+                        if (entry.size < 28)
+                            break;
+
                         XdbfAchievement achievement = new XdbfAchievement();
                         achievement.magic = ReverseEndianness(BitConverter.ToUInt32(entry.data, index));
                         index += 4;
@@ -125,6 +130,20 @@ namespace PlayniteAchievements.Providers.Xenia
                         index += 4;
                         achievement.flags = ReverseEndianness(BitConverter.ToUInt32(entry.data, index));
                         index += 4;
+
+                        // This check is really just for gpd files that come from an actual xbox 360
+                        // Check to see if achievements have been synced to file
+                        if (achievement.flags == 0)
+                            break;
+
+                        // This check is also for achievements from an actual xbox 360 as xenia will always put the date in the file
+                        // Check to see if achievement earned flag has been set
+                        achievement.earned = false;
+                        if ((achievement.flags & 131072) == 131072)
+                        {
+                            achievement.earned = true;
+                        }
+
                         achievement.unlock_time = ReverseEndianness(BitConverter.ToUInt64(entry.data, index));
                         index += 8;
 

--- a/source/Providers/Xenia/Models/XdbfModels.cs
+++ b/source/Providers/Xenia/Models/XdbfModels.cs
@@ -35,6 +35,7 @@ namespace PlayniteAchievements.Providers.Xenia.Models
         public UInt32 id;
         public UInt32 gamerscore;
         public UInt32 flags;
+        public bool earned;
         public UInt64 unlock_time;
         public string title;
         public string description;

--- a/source/Providers/Xenia/XeniaScanner.cs
+++ b/source/Providers/Xenia/XeniaScanner.cs
@@ -156,7 +156,7 @@ namespace PlayniteAchievements.Providers.Xenia
                         LockedIconPath = iconPath,
                         Points = (int?)achievement.gamerscore,
                         Rarity = GetRarityFromXboxPoints((int?)achievement.gamerscore),
-                        Unlocked = achievement.unlock_time != 0,
+                        Unlocked = achievement.earned,
                         UnlockTimeUtc = achievement.unlock_time != 0
                             ? DateTime.FromFileTimeUtc((Int64)achievement.unlock_time)
                             : (DateTime?)null,


### PR DESCRIPTION
Based on some user feedback I have added some checks as .gpd files from a real Xbox 360 can have offline achievements which will cause the current scanner to think that they are locked  as no date is assigned to them.
So, I have added a proper check to see if the achievement has been unlock by checking the flags and also accounted for some weird "Achievement" entries that can appear in real Xbox 360 .gpd files.