### PR TITLE
feat: support new shadPS4 AppData trophy paths

### DIFF
--- a/source/Providers/RetroAchievements/RetroAchievementsScanner.cs
+++ b/source/Providers/RetroAchievements/RetroAchievementsScanner.cs
@@ -613,7 +613,8 @@ namespace PlayniteAchievements.Providers.RetroAchievements
                     Points = ach.Points,
                     ScaledPoints = ach.TrueRatio,
                     Category = categoryLabel,
-                    IsCapstone = string.Equals(ach.Type, "win_condition", StringComparison.OrdinalIgnoreCase),
+                    // IsCapstone = string.Equals(ach.Type, "win_condition", StringComparison.OrdinalIgnoreCase),
+                    IsCapstone  = false,
                     UnlockTimeUtc = unlockUtc,
                     Hidden = false,
                     Rarity = globalPercent.HasValue

--- a/source/Providers/ShadPS4/ShadPS4DataProvider.cs
+++ b/source/Providers/ShadPS4/ShadPS4DataProvider.cs
@@ -11,6 +11,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using PlayniteAchievements.Common;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace PlayniteAchievements.Providers.ShadPS4
 {
@@ -24,6 +26,12 @@ namespace PlayniteAchievements.Providers.ShadPS4
 
         private Dictionary<string, string> _titleCache;
         private readonly object _cacheLock = new object();
+
+        private Dictionary<string, string> _npCommIdCache;
+        private readonly object _npCommIdCacheLock = new object();
+
+        private static readonly Regex NpCommIdPattern =
+            new Regex(@"(NPWR\d{5}_\d{2})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public ShadPS4DataProvider(ILogger logger, PlayniteAchievementsSettings settings, IPlayniteAPI playniteApi)
         {
@@ -59,7 +67,22 @@ namespace PlayniteAchievements.Providers.ShadPS4
             get
             {
                 var gameDataPath = GetGameDataPath();
-                return !string.IsNullOrWhiteSpace(gameDataPath) && Directory.Exists(gameDataPath);
+                if (!string.IsNullOrWhiteSpace(gameDataPath) && Directory.Exists(gameDataPath))
+                {
+                    return true;
+                }
+
+                var appDataPath = GetAppDataPath();
+                if (!string.IsNullOrWhiteSpace(appDataPath))
+                {
+                    var trophyUserPath = GetTrophyUserPath(appDataPath);
+                    if (!string.IsNullOrWhiteSpace(trophyUserPath) && Directory.Exists(trophyUserPath))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
         }
 
@@ -170,9 +193,19 @@ namespace PlayniteAchievements.Providers.ShadPS4
 
             if (usesShadPs4)
             {
-                // Emulator matches, but still verify title ID can be extracted
-                var titleId = ExtractTitleIdFromGame(game);
+                // Try new format first: resolve npcommid from npbind.dat
+                var npcommid = ResolveNpCommIdForGame(game);
+                if (!string.IsNullOrWhiteSpace(npcommid))
+                {
+                    var npCommIdCache = GetOrBuildNpCommIdCache();
+                    if (npCommIdCache != null && npCommIdCache.ContainsKey(npcommid))
+                    {
+                        return true;
+                    }
+                }
 
+                // Fall back to old format: verify title ID in cache
+                var titleId = ExtractTitleIdFromGame(game);
                 if (!string.IsNullOrWhiteSpace(titleId))
                 {
                     var cache = GetOrBuildTitleCache();
@@ -181,20 +214,34 @@ namespace PlayniteAchievements.Providers.ShadPS4
                         return true;
                     }
                 }
+
                 // Even without cache match, if emulator is ShadPS4, game may be capable
                 return true;
             }
 
-            // Extract title ID from game's install directory and look it up in cache
+            // Extract title ID from game's install directory and look up in cache
             var titleId2 = ExtractTitleIdFromGame(game);
-
-            if (string.IsNullOrWhiteSpace(titleId2))
+            if (!string.IsNullOrWhiteSpace(titleId2))
             {
-                return false;
+                var cache2 = GetOrBuildTitleCache();
+                if (cache2 != null && cache2.ContainsKey(titleId2))
+                {
+                    return true;
+                }
             }
 
-            var cache2 = GetOrBuildTitleCache();
-            return cache2 != null && cache2.ContainsKey(titleId2);
+            // Also try new format for non-emulator-matched games
+            var npcommid2 = ResolveNpCommIdForGame(game);
+            if (!string.IsNullOrWhiteSpace(npcommid2))
+            {
+                var npCommIdCache2 = GetOrBuildNpCommIdCache();
+                if (npCommIdCache2 != null && npCommIdCache2.ContainsKey(npcommid2))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -383,6 +430,196 @@ namespace PlayniteAchievements.Providers.ShadPS4
 
         /// <inheritdoc />
         public ProviderSettingsViewBase CreateSettingsView() => new ShadPS4SettingsView(_playniteApi);
+
+        #region New-format (AppData) path discovery
+
+        /// <summary>
+        /// Auto-discovers the shadPS4 AppData directory.
+        /// </summary>
+        internal string GetAppDataPath()
+        {
+            try
+            {
+                var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+                var shadps4Path = Path.Combine(appData, "shadPS4");
+                if (Directory.Exists(shadps4Path))
+                {
+                    return shadps4Path;
+                }
+            }
+            catch { }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Discovers the shadPS4 user ID by scanning the home directory.
+        /// Defaults to "1000" if no users are found.
+        /// </summary>
+        internal string GetUserId()
+        {
+            var appDataPath = GetAppDataPath();
+            if (!string.IsNullOrWhiteSpace(appDataPath))
+            {
+                var homePath = Path.Combine(appDataPath, "home");
+                if (Directory.Exists(homePath))
+                {
+                    try
+                    {
+                        var dirs = Directory.GetDirectories(homePath);
+                        if (dirs.Length > 0)
+                        {
+                            return Path.GetFileName(dirs[0].TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                        }
+                    }
+                    catch { }
+                }
+            }
+
+            return "1000";
+        }
+
+        /// <summary>
+        /// Returns the per-user trophy XML directory path: home/{userId}/trophy/
+        /// </summary>
+        internal string GetTrophyUserPath(string appDataPath = null)
+        {
+            var basePath = appDataPath ?? GetAppDataPath();
+            if (string.IsNullOrWhiteSpace(basePath)) return null;
+
+            var userId = GetUserId();
+            return Path.Combine(basePath, "home", userId, "trophy");
+        }
+
+        /// <summary>
+        /// Returns the shared trophy base directory path: trophy/
+        /// Contains subdirectories per npcommid with Xml/ and Icons/.
+        /// </summary>
+        internal string GetTrophyBasePath(string appDataPath = null)
+        {
+            var basePath = appDataPath ?? GetAppDataPath();
+            if (string.IsNullOrWhiteSpace(basePath)) return null;
+
+            return Path.Combine(basePath, "trophy");
+        }
+
+        #endregion
+
+        #region npcommid cache
+
+        internal Dictionary<string, string> GetOrBuildNpCommIdCache()
+        {
+            lock (_npCommIdCacheLock)
+            {
+                if (_npCommIdCache != null)
+                {
+                    return _npCommIdCache;
+                }
+                _npCommIdCache = BuildNpCommIdCache();
+                return _npCommIdCache;
+            }
+        }
+
+        internal void ClearNpCommIdCache()
+        {
+            lock (_npCommIdCacheLock)
+            {
+                _npCommIdCache = null;
+            }
+        }
+
+        /// <summary>
+        /// Builds a cache of npcommid to per-user trophy XML path.
+        /// Scans home/{userId}/trophy/ for XML files named by npcommid.
+        /// </summary>
+        private Dictionary<string, string> BuildNpCommIdCache()
+        {
+            var cache = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var userTrophyPath = GetTrophyUserPath();
+            if (string.IsNullOrWhiteSpace(userTrophyPath) || !Directory.Exists(userTrophyPath))
+            {
+                return cache;
+            }
+
+            try
+            {
+                var files = Directory.GetFiles(userTrophyPath, "*.xml");
+                foreach (var file in files)
+                {
+                    var npcommid = Path.GetFileNameWithoutExtension(file);
+                    if (!string.IsNullOrWhiteSpace(npcommid) && NpCommIdPattern.IsMatch(npcommid))
+                    {
+                        cache[npcommid.ToUpperInvariant()] = file;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.Error(ex, "[ShadPS4] Failed to enumerate new-format trophy files.");
+            }
+
+            return cache;
+        }
+
+        #endregion
+
+        #region npbind.dat parsing
+
+        /// <summary>
+        /// Resolves the npcommid for a game by parsing its sce_sys/npbind.dat file.
+        /// </summary>
+        internal string ResolveNpCommIdForGame(Game game)
+        {
+            var rawInstallDir = game?.InstallDirectory;
+            var installDir = ExpandGamePath(game, rawInstallDir);
+            if (string.IsNullOrWhiteSpace(installDir)) return null;
+
+            var searchDirs = new List<string> { installDir };
+
+            var normalized = installDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var parentDir = Path.GetDirectoryName(normalized);
+            if (!string.IsNullOrWhiteSpace(parentDir) && !PathsEqual(parentDir, installDir))
+            {
+                searchDirs.Add(parentDir);
+            }
+
+            foreach (var dir in searchDirs)
+            {
+                var npbindPath = Path.Combine(dir, "sce_sys", "npbind.dat");
+                if (File.Exists(npbindPath))
+                {
+                    return ExtractNpCommIdFromNpbind(npbindPath);
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Extracts the first npcommid from a binary npbind.dat file
+        /// by searching for the NPWR pattern in raw bytes.
+        /// </summary>
+        private string ExtractNpCommIdFromNpbind(string npbindPath)
+        {
+            try
+            {
+                var bytes = File.ReadAllBytes(npbindPath);
+                var content = Encoding.ASCII.GetString(bytes);
+                var match = NpCommIdPattern.Match(content);
+                if (match.Success)
+                {
+                    return match.Groups[1].Value.ToUpperInvariant();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.Debug(ex, $"[ShadPS4] Failed to parse npbind.dat at '{npbindPath}'");
+            }
+            return null;
+        }
+
+        #endregion
     }
 }
 

--- a/source/Providers/ShadPS4/ShadPS4DataProvider.cs
+++ b/source/Providers/ShadPS4/ShadPS4DataProvider.cs
@@ -188,54 +188,28 @@ namespace PlayniteAchievements.Providers.ShadPS4
         {
             if (game == null) return false;
 
-            // Check if game is configured to use ShadPS4 emulator (by path or name)
-            var usesShadPs4 = UsesShadPS4Emulator(game);
-
-            if (usesShadPs4)
+            // If game is configured to use ShadPS4 emulator, it's capable
+            if (UsesShadPS4Emulator(game))
             {
-                // Try new format first: resolve npcommid from npbind.dat
-                var npcommid = ResolveNpCommIdForGame(game);
-                if (!string.IsNullOrWhiteSpace(npcommid))
-                {
-                    var npCommIdCache = GetOrBuildNpCommIdCache();
-                    if (npCommIdCache != null && npCommIdCache.ContainsKey(npcommid))
-                    {
-                        return true;
-                    }
-                }
-
-                // Fall back to old format: verify title ID in cache
-                var titleId = ExtractTitleIdFromGame(game);
-                if (!string.IsNullOrWhiteSpace(titleId))
-                {
-                    var cache = GetOrBuildTitleCache();
-                    if (cache != null && cache.ContainsKey(titleId))
-                    {
-                        return true;
-                    }
-                }
-
-                // Even without cache match, if emulator is ShadPS4, game may be capable
                 return true;
             }
 
-            // Extract title ID from game's install directory and look up in cache
-            var titleId2 = ExtractTitleIdFromGame(game);
-            if (!string.IsNullOrWhiteSpace(titleId2))
+            // Otherwise, check if we can find trophy data by title ID or npcommid
+            var titleId = ExtractTitleIdFromGame(game);
+            if (!string.IsNullOrWhiteSpace(titleId))
             {
-                var cache2 = GetOrBuildTitleCache();
-                if (cache2 != null && cache2.ContainsKey(titleId2))
+                var cache = GetOrBuildTitleCache();
+                if (cache != null && cache.ContainsKey(titleId))
                 {
                     return true;
                 }
             }
 
-            // Also try new format for non-emulator-matched games
-            var npcommid2 = ResolveNpCommIdForGame(game);
-            if (!string.IsNullOrWhiteSpace(npcommid2))
+            var npcommid = ResolveNpCommIdForGame(game);
+            if (!string.IsNullOrWhiteSpace(npcommid))
             {
-                var npCommIdCache2 = GetOrBuildNpCommIdCache();
-                if (npCommIdCache2 != null && npCommIdCache2.ContainsKey(npcommid2))
+                var npCommIdCache = GetOrBuildNpCommIdCache();
+                if (npCommIdCache != null && npCommIdCache.ContainsKey(npcommid))
                 {
                     return true;
                 }
@@ -431,8 +405,6 @@ namespace PlayniteAchievements.Providers.ShadPS4
         /// <inheritdoc />
         public ProviderSettingsViewBase CreateSettingsView() => new ShadPS4SettingsView(_playniteApi);
 
-        #region New-format (AppData) path discovery
-
         /// <summary>
         /// Auto-discovers the shadPS4 AppData directory.
         /// </summary>
@@ -503,10 +475,6 @@ namespace PlayniteAchievements.Providers.ShadPS4
             return Path.Combine(basePath, "trophy");
         }
 
-        #endregion
-
-        #region npcommid cache
-
         internal Dictionary<string, string> GetOrBuildNpCommIdCache()
         {
             lock (_npCommIdCacheLock)
@@ -562,10 +530,6 @@ namespace PlayniteAchievements.Providers.ShadPS4
             return cache;
         }
 
-        #endregion
-
-        #region npbind.dat parsing
-
         /// <summary>
         /// Resolves the npcommid for a game by parsing its sce_sys/npbind.dat file.
         /// </summary>
@@ -618,8 +582,6 @@ namespace PlayniteAchievements.Providers.ShadPS4
             }
             return null;
         }
-
-        #endregion
     }
 }
 

--- a/source/Providers/ShadPS4/ShadPS4Scanner.cs
+++ b/source/Providers/ShadPS4/ShadPS4Scanner.cs
@@ -47,7 +47,7 @@ namespace PlayniteAchievements.Providers.ShadPS4
                 return new RebuildPayload { Summary = new RebuildSummary() };
             }
 
-            // Use the provider's cache if available, otherwise build our own
+            // Build caches for both old and new formats
             Dictionary<string, string> titleCache;
             if (_provider != null)
             {
@@ -58,20 +58,40 @@ namespace PlayniteAchievements.Providers.ShadPS4
                 titleCache = await BuildTitleIdCacheAsync(cancel).ConfigureAwait(false);
             }
 
-            if (titleCache == null || titleCache.Count == 0)
+            Dictionary<string, string> npCommIdCache;
+            if (_provider != null)
             {
-                _logger?.Warn("[ShadPS4] No games found in ShadPS4 user/game_data folder.");
+                npCommIdCache = _provider.GetOrBuildNpCommIdCache();
+            }
+            else
+            {
+                npCommIdCache = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            var hasOldData = titleCache != null && titleCache.Count > 0;
+            var hasNewData = npCommIdCache != null && npCommIdCache.Count > 0;
+
+            if (!hasOldData && !hasNewData)
+            {
+                _logger?.Warn("[ShadPS4] No games found in any ShadPS4 trophy location.");
                 return new RebuildPayload { Summary = new RebuildSummary() };
             }
 
-            _logger?.Info($"[ShadPS4] Scanning {titleCache.Count} titles from game_data folder.");
+            if (hasOldData)
+            {
+                _logger?.Info($"[ShadPS4] Found {titleCache.Count} titles in old game_data format.");
+            }
+            if (hasNewData)
+            {
+                _logger?.Info($"[ShadPS4] Found {npCommIdCache.Count} titles in new AppData format.");
+            }
 
             return await ProviderRefreshExecutor.RunProviderGamesAsync(
                 gamesToRefresh,
                 onGameStarting,
                 async (game, token) =>
                 {
-                    var data = await FetchGameDataAsync(game, titleCache, token).ConfigureAwait(false);
+                    var data = await FetchGameDataAsync(game, titleCache, npCommIdCache, token).ConfigureAwait(false);
                     return new ProviderRefreshExecutor.ProviderGameResult
                     {
                         Data = data
@@ -203,6 +223,32 @@ namespace PlayniteAchievements.Providers.ShadPS4
         private Task<GameAchievementData> FetchGameDataAsync(
             Game game,
             Dictionary<string, string> titleCache,
+            Dictionary<string, string> npCommIdCache,
+            CancellationToken cancel)
+        {
+            if (game == null)
+            {
+                return Task.FromResult<GameAchievementData>(null);
+            }
+
+            // Try new format first: resolve npcommid from npbind.dat
+            if (npCommIdCache != null && npCommIdCache.Count > 0)
+            {
+                var npcommid = _provider?.ResolveNpCommIdForGame(game);
+                if (!string.IsNullOrWhiteSpace(npcommid) &&
+                    npCommIdCache.TryGetValue(npcommid, out var perUserXmlPath))
+                {
+                    return FetchGameDataNewFormatAsync(game, npcommid, perUserXmlPath, cancel);
+                }
+            }
+
+            // Fall back to old format: title ID lookup
+            return FetchGameDataOldFormatAsync(game, titleCache, cancel);
+        }
+
+        private Task<GameAchievementData> FetchGameDataOldFormatAsync(
+            Game game,
+            Dictionary<string, string> titleCache,
             CancellationToken cancel)
         {
             if (game == null)
@@ -310,6 +356,136 @@ namespace PlayniteAchievements.Providers.ShadPS4
             {
                 _logger?.Error(ex, $"[ShadPS4] Failed to parse TROP.XML for {game.Name}");
                 return Task.FromResult(BuildNoAchievementsData(game));
+            }
+        }
+
+        /// <summary>
+        /// Fetches trophy data from the new AppData-based format.
+        /// The per-user XML contains the full trophy config with unlock state.
+        /// Icons are loaded from the shared trophy base directory.
+        /// </summary>
+        private Task<GameAchievementData> FetchGameDataNewFormatAsync(
+            Game game,
+            string npcommid,
+            string perUserXmlPath,
+            CancellationToken cancel)
+        {
+            if (!File.Exists(perUserXmlPath))
+            {
+                return Task.FromResult(BuildNoAchievementsData(game));
+            }
+
+            cancel.ThrowIfCancellationRequested();
+
+            // Icons are in the shared trophy base directory
+            var appDataPath = _provider?.GetAppDataPath();
+            var iconsFolder = !string.IsNullOrWhiteSpace(appDataPath)
+                ? Path.Combine(appDataPath, "trophy", npcommid, "Icons")
+                : null;
+
+            try
+            {
+                var doc = XDocument.Load(perUserXmlPath);
+                var achievements = new List<AchievementDetail>();
+                var unlockedCount = 0;
+                var groupNamesById = BuildGroupNamesDictionary(doc);
+
+                var ps4Locale = MapGlobalLanguageToPs4Locale(_settings?.Persisted?.GlobalLanguage);
+
+                foreach (var trophyElement in doc.Descendants("trophy"))
+                {
+                    cancel.ThrowIfCancellationRequested();
+
+                    var trophyId = trophyElement.Attribute("id")?.Value;
+                    var trophyType = trophyElement.Attribute("ttype")?.Value;
+                    var isHidden = trophyElement.Attribute("hidden")?.Value == "yes";
+                    var name = GetLocalizedElement(trophyElement, "name", ps4Locale)?.Trim();
+                    var description = GetLocalizedElement(trophyElement, "detail", ps4Locale)?.Trim();
+                    var groupId = trophyElement.Attribute("gid")?.Value?.Trim();
+                    groupId = string.IsNullOrWhiteSpace(groupId) ? "0" : groupId;
+                    groupNamesById.TryGetValue(groupId, out var groupName);
+
+                    // New format: unlockstate is "true" or "false" (always present)
+                    var unlockStateValue = trophyElement.Attribute("unlockstate")?.Value;
+                    var isUnlocked = string.Equals(unlockStateValue, "true", StringComparison.OrdinalIgnoreCase);
+                    DateTime? unlockTime = null;
+
+                    if (isUnlocked)
+                    {
+                        unlockedCount++;
+                        var timestamp = trophyElement.Attribute("timestamp")?.Value;
+                        unlockTime = ConvertUnixTimestamp(timestamp);
+                    }
+
+                    string trophyTypeNormalized = NormalizeTrophyType(trophyType);
+
+                    var iconPath = iconsFolder != null
+                        ? GetTrophyIconPath(iconsFolder, trophyId)
+                        : null;
+
+                    achievements.Add(new AchievementDetail
+                    {
+                        ApiName = trophyId,
+                        DisplayName = name,
+                        Description = description,
+                        UnlockedIconPath = iconPath,
+                        LockedIconPath = iconPath,
+                        Hidden = isHidden,
+                        Unlocked = isUnlocked,
+                        UnlockTimeUtc = unlockTime,
+                        GlobalPercentUnlocked = null,
+                        Rarity = GetRarityFromTrophyType(trophyTypeNormalized),
+                        TrophyType = trophyTypeNormalized,
+                        IsCapstone = trophyType?.ToUpperInvariant() == "P",
+                        CategoryType = MapGroupIdToCategoryType(groupId),
+                        Category = string.IsNullOrWhiteSpace(groupName) ? null : groupName.Trim()
+                    });
+                }
+
+                _logger?.Info($"[ShadPS4] Parsed {achievements.Count} trophies (new format) for '{game.Name}' ({unlockedCount} unlocked)");
+
+                return Task.FromResult(new GameAchievementData
+                {
+                    ProviderKey = "ShadPS4",
+                    LibrarySourceName = game?.Source?.Name,
+                    GameName = game?.Name,
+                    PlayniteGameId = game?.Id,
+                    HasAchievements = achievements.Count > 0,
+                    Achievements = achievements,
+                    LastUpdatedUtc = DateTime.UtcNow
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger?.Error(ex, $"[ShadPS4] Failed to parse new-format trophy XML for {game.Name}");
+                return Task.FromResult(BuildNoAchievementsData(game));
+            }
+        }
+
+        /// <summary>
+        /// Converts a standard Unix timestamp (seconds since 1970-01-01) to UTC DateTime.
+        /// Used by the new AppData trophy format.
+        /// </summary>
+        private static DateTime? ConvertUnixTimestamp(string timestamp)
+        {
+            if (string.IsNullOrEmpty(timestamp))
+            {
+                return null;
+            }
+
+            try
+            {
+                var seconds = long.Parse(timestamp);
+                if (seconds <= 0)
+                {
+                    return null;
+                }
+
+                return DateTimeOffset.FromUnixTimeSeconds(seconds).UtcDateTime;
+            }
+            catch (Exception)
+            {
+                return null;
             }
         }
 

--- a/source/Providers/ShadPS4/ShadPS4Scanner.cs
+++ b/source/Providers/ShadPS4/ShadPS4Scanner.cs
@@ -24,8 +24,15 @@ namespace PlayniteAchievements.Providers.ShadPS4
         // PS4's RTC epoch is January 1, 2008 00:00:00 UTC
         private static readonly DateTime Ps4Epoch = new DateTime(2008, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-        // The consistent difference we need to subtract (ShadPS4-specific offset)
+        // ShadPS4-specific year offset correction
         private const int YearOffset = 2007;
+
+        // PS4 title ID patterns: CUSA (US), BCAS (Asia), PCAS (Asia digital), etc.
+        private static readonly System.Text.RegularExpressions.Regex TitleIdPattern =
+            new System.Text.RegularExpressions.Regex(@"\b([A-Z]{4}\d{5})\b",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        private enum TrophyFormat { Old, New }
 
         public ShadPS4Scanner(ILogger logger, PlayniteAchievementsSettings settings, ShadPS4Settings providerSettings, ShadPS4DataProvider provider = null, IPlayniteAPI playniteApi = null, string pluginUserDataPath = null)
         {
@@ -47,29 +54,16 @@ namespace PlayniteAchievements.Providers.ShadPS4
                 return new RebuildPayload { Summary = new RebuildSummary() };
             }
 
-            // Build caches for both old and new formats
-            Dictionary<string, string> titleCache;
-            if (_provider != null)
-            {
-                titleCache = _provider.GetOrBuildTitleCache();
-            }
-            else
-            {
-                titleCache = await BuildTitleIdCacheAsync(cancel).ConfigureAwait(false);
-            }
+            var titleCache = _provider != null
+                ? _provider.GetOrBuildTitleCache()
+                : await BuildTitleIdCacheAsync(cancel).ConfigureAwait(false);
 
-            Dictionary<string, string> npCommIdCache;
-            if (_provider != null)
-            {
-                npCommIdCache = _provider.GetOrBuildNpCommIdCache();
-            }
-            else
-            {
-                npCommIdCache = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            }
+            var npCommIdCache = _provider != null
+                ? _provider.GetOrBuildNpCommIdCache()
+                : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-            var hasOldData = titleCache != null && titleCache.Count > 0;
-            var hasNewData = npCommIdCache != null && npCommIdCache.Count > 0;
+            var hasOldData = titleCache?.Count > 0;
+            var hasNewData = npCommIdCache?.Count > 0;
 
             if (!hasOldData && !hasNewData)
             {
@@ -78,13 +72,9 @@ namespace PlayniteAchievements.Providers.ShadPS4
             }
 
             if (hasOldData)
-            {
                 _logger?.Info($"[ShadPS4] Found {titleCache.Count} titles in old game_data format.");
-            }
             if (hasNewData)
-            {
                 _logger?.Info($"[ShadPS4] Found {npCommIdCache.Count} titles in new AppData format.");
-            }
 
             return await ProviderRefreshExecutor.RunProviderGamesAsync(
                 gamesToRefresh,
@@ -92,30 +82,20 @@ namespace PlayniteAchievements.Providers.ShadPS4
                 async (game, token) =>
                 {
                     var data = await FetchGameDataAsync(game, titleCache, npCommIdCache, token).ConfigureAwait(false);
-                    return new ProviderRefreshExecutor.ProviderGameResult
-                    {
-                        Data = data
-                    };
+                    return new ProviderRefreshExecutor.ProviderGameResult { Data = data };
                 },
                 onGameCompleted,
                 isAuthRequiredException: _ => false,
                 onGameError: (game, ex, consecutiveErrors) =>
-                {
-                    _logger?.Error(ex, $"[ShadPS4] Error processing game '{game?.Name}'");
-                },
+                    _logger?.Error(ex, $"[ShadPS4] Error processing game '{game?.Name}'"),
                 delayBetweenGamesAsync: null,
                 delayAfterErrorAsync: null,
                 cancel).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Builds a cache of title ID to trophy data directory path.
-        /// Cache structure: title_id (e.g., "CUSA00432") -> full path to game_data directory
-        /// </summary>
         private async Task<Dictionary<string, string>> BuildTitleIdCacheAsync(CancellationToken cancel)
         {
             var cache = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
             var gameDataPath = _providerSettings?.GameDataPath;
 
             if (string.IsNullOrWhiteSpace(gameDataPath))
@@ -132,24 +112,15 @@ namespace PlayniteAchievements.Providers.ShadPS4
 
             try
             {
-                var titleDirectories = Directory.GetDirectories(gameDataPath);
-
-                foreach (var titleDir in titleDirectories)
+                foreach (var titleDir in Directory.GetDirectories(gameDataPath))
                 {
                     cancel.ThrowIfCancellationRequested();
-
                     var titleId = Path.GetFileName(titleDir);
-                    if (string.IsNullOrWhiteSpace(titleId))
-                    {
-                        continue;
-                    }
+                    if (string.IsNullOrWhiteSpace(titleId)) continue;
 
-                    // Verify trophy data exists
                     var xmlPath = Path.Combine(titleDir, "trophyfiles", "trophy00", "Xml", "TROP.XML");
                     if (File.Exists(xmlPath))
-                    {
                         cache[titleId.ToUpperInvariant()] = titleDir;
-                    }
                 }
             }
             catch (Exception ex)
@@ -160,66 +131,6 @@ namespace PlayniteAchievements.Providers.ShadPS4
             return await Task.FromResult(cache).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Extracts the PS4 title ID from the game's install directory path.
-        /// PS4 title IDs follow pattern: AAAA12345 (e.g., CUSA00432)
-        /// </summary>
-        private string ExtractTitleIdFromGame(Game game)
-        {
-            var rawInstallDir = game?.InstallDirectory;
-            if (string.IsNullOrWhiteSpace(rawInstallDir))
-            {
-                return null;
-            }
-
-            var installDir = ExpandGamePath(game, rawInstallDir);
-            if (string.IsNullOrWhiteSpace(installDir))
-            {
-                return null;
-            }
-
-            // Search for title ID pattern in the path
-            var match = TitleIdPattern.Match(installDir);
-            if (match.Success)
-            {
-                return match.Groups[1].Value.ToUpperInvariant();
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Expands path variables in game paths using Playnite's variable expansion.
-        /// </summary>
-        private string ExpandGamePath(Game game, string path)
-        {
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                return path;
-            }
-
-            // Use provider's expansion if available
-            if (_provider != null)
-            {
-                return _provider.ExpandGamePath(game, path);
-            }
-
-            // Fallback: use Playnite API directly if available
-            try
-            {
-                return _playniteApi?.ExpandGameVariables(game, path) ?? path;
-            }
-            catch
-            {
-                return path;
-            }
-        }
-
-        // PS4 title ID patterns: CUSA (US), BCAS (Asia), PCAS (Asia digital), etc.
-        private static readonly System.Text.RegularExpressions.Regex TitleIdPattern =
-            new System.Text.RegularExpressions.Regex(@"\b([A-Z]{4}\d{5})\b",
-                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-
         private Task<GameAchievementData> FetchGameDataAsync(
             Game game,
             Dictionary<string, string> titleCache,
@@ -227,59 +138,51 @@ namespace PlayniteAchievements.Providers.ShadPS4
             CancellationToken cancel)
         {
             if (game == null)
-            {
                 return Task.FromResult<GameAchievementData>(null);
-            }
 
-            // Try new format first: resolve npcommid from npbind.dat
-            if (npCommIdCache != null && npCommIdCache.Count > 0)
+            // Try new format: resolve npcommid from npbind.dat
+            if (npCommIdCache?.Count > 0)
             {
                 var npcommid = _provider?.ResolveNpCommIdForGame(game);
                 if (!string.IsNullOrWhiteSpace(npcommid) &&
                     npCommIdCache.TryGetValue(npcommid, out var perUserXmlPath))
                 {
-                    return FetchGameDataNewFormatAsync(game, npcommid, perUserXmlPath, cancel);
+                    return ParseTrophyXml(game, perUserXmlPath, TrophyFormat.New, npcommid, cancel);
                 }
             }
 
             // Fall back to old format: title ID lookup
-            return FetchGameDataOldFormatAsync(game, titleCache, cancel);
+            var titleId = ExtractTitleIdFromGame(game);
+            if (string.IsNullOrWhiteSpace(titleId) || titleCache == null ||
+                !titleCache.TryGetValue(titleId, out var trophyDataPath))
+            {
+                return Task.FromResult(BuildNoAchievementsData(game));
+            }
+
+            var xmlPath = Path.Combine(trophyDataPath, "trophyfiles", "trophy00", "Xml", "TROP.XML");
+            if (!File.Exists(xmlPath))
+                return Task.FromResult(BuildNoAchievementsData(game));
+
+            return ParseTrophyXml(game, xmlPath, TrophyFormat.Old, null, cancel);
         }
 
-        private Task<GameAchievementData> FetchGameDataOldFormatAsync(
+        /// <summary>
+        /// Shared trophy XML parser for both old and new formats.
+        /// Differences are resolved via the format parameter and provider icon path helpers.
+        /// </summary>
+        private Task<GameAchievementData> ParseTrophyXml(
             Game game,
-            Dictionary<string, string> titleCache,
+            string xmlPath,
+            TrophyFormat format,
+            string npcommid,
             CancellationToken cancel)
         {
-            if (game == null)
-            {
-                return Task.FromResult<GameAchievementData>(null);
-            }
-
-            // Extract title ID from game's install directory
-            var titleId = ExtractTitleIdFromGame(game);
-
-            if (string.IsNullOrWhiteSpace(titleId))
-            {
+            if (!File.Exists(xmlPath))
                 return Task.FromResult(BuildNoAchievementsData(game));
-            }
-
-            // Look up trophy data directory in cache
-            if (!titleCache.TryGetValue(titleId, out var trophyDataPath))
-            {
-                return Task.FromResult(BuildNoAchievementsData(game));
-            }
 
             cancel.ThrowIfCancellationRequested();
 
-            var xmlPath = Path.Combine(trophyDataPath, "trophyfiles", "trophy00", "Xml", "TROP.XML");
-
-            if (!File.Exists(xmlPath))
-            {
-                return Task.FromResult(BuildNoAchievementsData(game));
-            }
-
-            var iconsFolder = Path.Combine(trophyDataPath, "trophyfiles", "trophy00", "Icons");
+            var iconsFolder = ResolveIconsFolder(format, npcommid, xmlPath);
 
             try
             {
@@ -287,8 +190,6 @@ namespace PlayniteAchievements.Providers.ShadPS4
                 var achievements = new List<AchievementDetail>();
                 var unlockedCount = 0;
                 var groupNamesById = BuildGroupNamesDictionary(doc);
-
-                // Map global language to PS4 locale (same format as PS3)
                 var ps4Locale = MapGlobalLanguageToPs4Locale(_settings?.Persisted?.GlobalLanguage);
 
                 foreach (var trophyElement in doc.Descendants("trophy"))
@@ -304,121 +205,31 @@ namespace PlayniteAchievements.Providers.ShadPS4
                     groupId = string.IsNullOrWhiteSpace(groupId) ? "0" : groupId;
                     groupNamesById.TryGetValue(groupId, out var groupName);
 
-                    // Check if trophy is unlocked
-                    var isUnlocked = trophyElement.Attribute("unlockstate") != null;
+                    bool isUnlocked;
                     DateTime? unlockTime = null;
 
-                    if (isUnlocked)
+                    if (format == TrophyFormat.New)
                     {
-                        unlockedCount++;
-                        var timestamp = trophyElement.Attribute("timestamp")?.Value;
-                        unlockTime = ConvertPs4Timestamp(timestamp);
+                        isUnlocked = string.Equals(
+                            trophyElement.Attribute("unlockstate")?.Value, "true",
+                            StringComparison.OrdinalIgnoreCase);
+                        if (isUnlocked)
+                        {
+                            unlockedCount++;
+                            unlockTime = ConvertUnixTimestamp(trophyElement.Attribute("timestamp")?.Value);
+                        }
+                    }
+                    else
+                    {
+                        isUnlocked = trophyElement.Attribute("unlockstate") != null;
+                        if (isUnlocked)
+                        {
+                            unlockedCount++;
+                            unlockTime = ConvertPs4Timestamp(trophyElement.Attribute("timestamp")?.Value);
+                        }
                     }
 
-                    string trophyTypeNormalized = NormalizeTrophyType(trophyType);
-
-                    // Build icon path - caching handled by DiskImageService
-                    var iconPath = GetTrophyIconPath(iconsFolder, trophyId);
-
-                    achievements.Add(new AchievementDetail
-                    {
-                        ApiName = trophyId,
-                        DisplayName = name,
-                        Description = description,
-                        UnlockedIconPath = iconPath,
-                        LockedIconPath = iconPath,
-                        Hidden = isHidden,
-                        Unlocked = isUnlocked,
-                        UnlockTimeUtc = unlockTime,
-                        GlobalPercentUnlocked = null,
-                        Rarity = GetRarityFromTrophyType(trophyTypeNormalized),
-                        TrophyType = trophyTypeNormalized,
-                        IsCapstone = trophyType?.ToUpperInvariant() == "P",
-                        CategoryType = MapGroupIdToCategoryType(groupId),
-                        Category = string.IsNullOrWhiteSpace(groupName) ? null : groupName.Trim()
-                    });
-                }
-
-                _logger?.Info($"[ShadPS4] Parsed {achievements.Count} trophies for '{game.Name}' ({unlockedCount} unlocked)");
-
-                return Task.FromResult(new GameAchievementData
-                {
-                    ProviderKey = "ShadPS4",
-                    LibrarySourceName = game?.Source?.Name,
-                    GameName = game?.Name,
-                    PlayniteGameId = game?.Id,
-                    HasAchievements = achievements.Count > 0,
-                    Achievements = achievements,
-                    LastUpdatedUtc = DateTime.UtcNow
-                });
-            }
-            catch (Exception ex)
-            {
-                _logger?.Error(ex, $"[ShadPS4] Failed to parse TROP.XML for {game.Name}");
-                return Task.FromResult(BuildNoAchievementsData(game));
-            }
-        }
-
-        /// <summary>
-        /// Fetches trophy data from the new AppData-based format.
-        /// The per-user XML contains the full trophy config with unlock state.
-        /// Icons are loaded from the shared trophy base directory.
-        /// </summary>
-        private Task<GameAchievementData> FetchGameDataNewFormatAsync(
-            Game game,
-            string npcommid,
-            string perUserXmlPath,
-            CancellationToken cancel)
-        {
-            if (!File.Exists(perUserXmlPath))
-            {
-                return Task.FromResult(BuildNoAchievementsData(game));
-            }
-
-            cancel.ThrowIfCancellationRequested();
-
-            // Icons are in the shared trophy base directory
-            var appDataPath = _provider?.GetAppDataPath();
-            var iconsFolder = !string.IsNullOrWhiteSpace(appDataPath)
-                ? Path.Combine(appDataPath, "trophy", npcommid, "Icons")
-                : null;
-
-            try
-            {
-                var doc = XDocument.Load(perUserXmlPath);
-                var achievements = new List<AchievementDetail>();
-                var unlockedCount = 0;
-                var groupNamesById = BuildGroupNamesDictionary(doc);
-
-                var ps4Locale = MapGlobalLanguageToPs4Locale(_settings?.Persisted?.GlobalLanguage);
-
-                foreach (var trophyElement in doc.Descendants("trophy"))
-                {
-                    cancel.ThrowIfCancellationRequested();
-
-                    var trophyId = trophyElement.Attribute("id")?.Value;
-                    var trophyType = trophyElement.Attribute("ttype")?.Value;
-                    var isHidden = trophyElement.Attribute("hidden")?.Value == "yes";
-                    var name = GetLocalizedElement(trophyElement, "name", ps4Locale)?.Trim();
-                    var description = GetLocalizedElement(trophyElement, "detail", ps4Locale)?.Trim();
-                    var groupId = trophyElement.Attribute("gid")?.Value?.Trim();
-                    groupId = string.IsNullOrWhiteSpace(groupId) ? "0" : groupId;
-                    groupNamesById.TryGetValue(groupId, out var groupName);
-
-                    // New format: unlockstate is "true" or "false" (always present)
-                    var unlockStateValue = trophyElement.Attribute("unlockstate")?.Value;
-                    var isUnlocked = string.Equals(unlockStateValue, "true", StringComparison.OrdinalIgnoreCase);
-                    DateTime? unlockTime = null;
-
-                    if (isUnlocked)
-                    {
-                        unlockedCount++;
-                        var timestamp = trophyElement.Attribute("timestamp")?.Value;
-                        unlockTime = ConvertUnixTimestamp(timestamp);
-                    }
-
-                    string trophyTypeNormalized = NormalizeTrophyType(trophyType);
-
+                    var trophyTypeNormalized = NormalizeTrophyType(trophyType);
                     var iconPath = iconsFolder != null
                         ? GetTrophyIconPath(iconsFolder, trophyId)
                         : null;
@@ -442,7 +253,8 @@ namespace PlayniteAchievements.Providers.ShadPS4
                     });
                 }
 
-                _logger?.Info($"[ShadPS4] Parsed {achievements.Count} trophies (new format) for '{game.Name}' ({unlockedCount} unlocked)");
+                var formatLabel = format == TrophyFormat.New ? "new format" : "old format";
+                _logger?.Info($"[ShadPS4] Parsed {achievements.Count} trophies ({formatLabel}) for '{game.Name}' ({unlockedCount} unlocked)");
 
                 return Task.FromResult(new GameAchievementData
                 {
@@ -457,74 +269,164 @@ namespace PlayniteAchievements.Providers.ShadPS4
             }
             catch (Exception ex)
             {
-                _logger?.Error(ex, $"[ShadPS4] Failed to parse new-format trophy XML for {game.Name}");
+                _logger?.Error(ex, $"[ShadPS4] Failed to parse trophy XML for {game.Name}");
                 return Task.FromResult(BuildNoAchievementsData(game));
             }
         }
 
+        private string ResolveIconsFolder(TrophyFormat format, string npcommid, string xmlPath)
+        {
+            if (format == TrophyFormat.New && !string.IsNullOrWhiteSpace(npcommid))
+            {
+                var appDataPath = _provider?.GetAppDataPath();
+                return !string.IsNullOrWhiteSpace(appDataPath)
+                    ? Path.Combine(appDataPath, "trophy", npcommid, "Icons")
+                    : null;
+            }
+
+            // Old format: icons are alongside the XML in ../Icons relative to Xml/
+            var xmlDir = Path.GetDirectoryName(xmlPath);
+            return xmlDir != null
+                ? Path.Combine(xmlDir, "..", "Icons")
+                : null;
+        }
+
+        #region Timestamp conversion
+
         /// <summary>
         /// Converts a standard Unix timestamp (seconds since 1970-01-01) to UTC DateTime.
-        /// Used by the new AppData trophy format.
         /// </summary>
         private static DateTime? ConvertUnixTimestamp(string timestamp)
         {
-            if (string.IsNullOrEmpty(timestamp))
-            {
-                return null;
-            }
-
+            if (string.IsNullOrEmpty(timestamp)) return null;
             try
             {
                 var seconds = long.Parse(timestamp);
-                if (seconds <= 0)
+                return seconds > 0 ? DateTimeOffset.FromUnixTimeSeconds(seconds).UtcDateTime : (DateTime?)null;
+            }
+            catch { return null; }
+        }
+
+        /// <summary>
+        /// Converts a PS4 RTC timestamp (microseconds since 2008-01-01 epoch)
+        /// with ShadPS4-specific year offset correction.
+        /// </summary>
+        private DateTime? ConvertPs4Timestamp(string timestamp)
+        {
+            if (string.IsNullOrEmpty(timestamp)) return null;
+            try
+            {
+                var milliseconds = (long)(ulong.Parse(timestamp) / 1000);
+                var utcTime = Ps4Epoch.AddMilliseconds(milliseconds);
+
+                if (utcTime.Year > YearOffset)
                 {
-                    return null;
+                    return new DateTime(
+                        utcTime.Year - YearOffset, utcTime.Month, utcTime.Day,
+                        utcTime.Hour, utcTime.Minute, utcTime.Second, utcTime.Millisecond,
+                        DateTimeKind.Utc);
                 }
 
-                return DateTimeOffset.FromUnixTimeSeconds(seconds).UtcDateTime;
+                return utcTime;
             }
-            catch (Exception)
-            {
-                return null;
-            }
+            catch { return null; }
         }
+
+        #endregion
+
+        #region XML helpers
 
         private static Dictionary<string, string> BuildGroupNamesDictionary(XDocument doc)
         {
             var groups = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            if (doc == null)
-            {
-                return groups;
-            }
+            if (doc == null) return groups;
 
             foreach (var groupElement in doc.Descendants("group"))
             {
                 var id = groupElement.Attribute("id")?.Value?.Trim();
                 var name = groupElement.Element("name")?.Value?.Trim();
-                if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(name))
-                {
-                    continue;
-                }
-
-                groups[id] = name;
+                if (!string.IsNullOrWhiteSpace(id) && !string.IsNullOrWhiteSpace(name))
+                    groups[id] = name;
             }
 
             return groups;
         }
 
+        private static string GetLocalizedElement(XElement trophyElement, string elementName, string language)
+        {
+            if (string.IsNullOrWhiteSpace(language))
+                return trophyElement.Element(elementName)?.Value;
+
+            var localized = trophyElement.Elements(elementName)
+                .FirstOrDefault(e => string.Equals(e.Attribute("lang")?.Value, language, StringComparison.OrdinalIgnoreCase));
+            if (localized != null) return localized.Value;
+
+            return trophyElement.Elements(elementName)
+                .FirstOrDefault(e => e.Attribute("lang") == null)?.Value
+                ?? trophyElement.Element(elementName)?.Value;
+        }
+
+        private static string MapGlobalLanguageToPs4Locale(string globalLanguage)
+        {
+            if (string.IsNullOrWhiteSpace(globalLanguage)) return null;
+            return globalLanguage.Trim().ToLowerInvariant() switch
+            {
+                "english" => "en", "french" => "fr", "spanish" => "es",
+                "german" => "de", "italian" => "it", "japanese" => "ja",
+                "dutch" => "nl", "portuguese" => "pt", "russian" => "ru",
+                "korean" => "ko", "chinese" => "zh", "polish" => "pl",
+                "danish" => "da", "finnish" => "fi", "norwegian" => "no",
+                "swedish" => "sv", "turkish" => "tr", "czech" => "cs",
+                "hungarian" => "hu", "greek" => "el",
+                "brazilian" => "pt-br", "latam" => "es-419",
+                _ => null
+            };
+        }
+
+        #endregion
+
+        #region Trophy metadata helpers
+
+        private string GetTrophyIconPath(string iconsFolder, string trophyId)
+        {
+            if (string.IsNullOrWhiteSpace(trophyId)) return null;
+            try
+            {
+                var iconPath = Path.Combine(iconsFolder, $"TROP{trophyId.PadLeft(3, '0')}.PNG");
+                return File.Exists(iconPath) ? iconPath : null;
+            }
+            catch { return null; }
+        }
+
+        private static string NormalizeTrophyType(string trophyType)
+        {
+            if (string.IsNullOrWhiteSpace(trophyType)) return null;
+            return trophyType.ToUpperInvariant() switch
+            {
+                "P" => "platinum", "G" => "gold", "S" => "silver", "B" => "bronze", _ => null
+            };
+        }
+
+        private static RarityTier GetRarityFromTrophyType(string trophyType)
+        {
+            switch ((trophyType ?? string.Empty).Trim().ToLowerInvariant())
+            {
+                case "platinum": case "p": return RarityTier.UltraRare;
+                case "gold": case "g": return RarityTier.Rare;
+                case "silver": case "s": return RarityTier.Uncommon;
+                default: return RarityTier.Common;
+            }
+        }
+
         private static string MapGroupIdToCategoryType(string groupId)
         {
-            var normalized = (groupId ?? string.Empty).Trim();
-            if (string.IsNullOrWhiteSpace(normalized) ||
-                string.Equals(normalized, "0", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(normalized, "000", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(normalized, "default", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(normalized, "base", StringComparison.OrdinalIgnoreCase))
-            {
-                return "Base";
-            }
-
-            return "DLC";
+            var n = (groupId ?? string.Empty).Trim();
+            return string.IsNullOrWhiteSpace(n) ||
+                n.Equals("0", StringComparison.OrdinalIgnoreCase) ||
+                n.Equals("000", StringComparison.OrdinalIgnoreCase) ||
+                n.Equals("default", StringComparison.OrdinalIgnoreCase) ||
+                n.Equals("base", StringComparison.OrdinalIgnoreCase)
+                ? "Base" : "DLC";
         }
 
         private static GameAchievementData BuildNoAchievementsData(Game game)
@@ -540,182 +442,30 @@ namespace PlayniteAchievements.Providers.ShadPS4
             };
         }
 
-        /// <summary>
-        /// Converts a PS4 timestamp to UTC DateTime.
-        /// PS4 epoch: 2008-01-01 00:00:00 UTC
-        /// Format: Microseconds since epoch
-        /// Correction: Subtract 2007 years from result (ShadPS4-specific offset)
-        /// </summary>
-        private DateTime? ConvertPs4Timestamp(string timestamp)
+        #endregion
+
+        #region Game path helpers
+
+        private string ExtractTitleIdFromGame(Game game)
         {
-            if (string.IsNullOrEmpty(timestamp))
-            {
-                return null;
-            }
+            var rawInstallDir = game?.InstallDirectory;
+            if (string.IsNullOrWhiteSpace(rawInstallDir)) return null;
 
-            try
-            {
-                var tickValue = ulong.Parse(timestamp);
+            var installDir = ExpandGamePath(game, rawInstallDir);
+            if (string.IsNullOrWhiteSpace(installDir)) return null;
 
-                // Divide by 1000 to get milliseconds instead of microseconds
-                var milliseconds = (long)(tickValue / 1000);
-
-                // Add milliseconds to PS4 epoch
-                var utcTime = Ps4Epoch.AddMilliseconds(milliseconds);
-
-                // Adjust the year by subtracting the offset
-                if (utcTime.Year > YearOffset)
-                {
-                    return new DateTime(
-                        utcTime.Year - YearOffset,
-                        utcTime.Month,
-                        utcTime.Day,
-                        utcTime.Hour,
-                        utcTime.Minute,
-                        utcTime.Second,
-                        utcTime.Millisecond,
-                        DateTimeKind.Utc);
-                }
-
-                return utcTime;
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+            var match = TitleIdPattern.Match(installDir);
+            return match.Success ? match.Groups[1].Value.ToUpperInvariant() : null;
         }
 
-        private static string NormalizeTrophyType(string trophyType)
+        private string ExpandGamePath(Game game, string path)
         {
-            if (string.IsNullOrWhiteSpace(trophyType))
-            {
-                return null;
-            }
-
-            return trophyType.ToUpperInvariant() switch
-            {
-                "P" => "platinum",
-                "G" => "gold",
-                "S" => "silver",
-                "B" => "bronze",
-                _ => null
-            };
+            if (string.IsNullOrWhiteSpace(path)) return path;
+            if (_provider != null) return _provider.ExpandGamePath(game, path);
+            try { return _playniteApi?.ExpandGameVariables(game, path) ?? path; }
+            catch { return path; }
         }
 
-        private static RarityTier GetRarityFromTrophyType(string trophyType)
-        {
-            switch ((trophyType ?? string.Empty).Trim().ToLowerInvariant())
-            {
-                case "platinum":
-                case "p":
-                    return RarityTier.UltraRare;
-                case "gold":
-                case "g":
-                    return RarityTier.Rare;
-                case "silver":
-                case "s":
-                    return RarityTier.Uncommon;
-                default:
-                    return RarityTier.Common;
-            }
-        }
-
-        /// <summary>
-        /// Gets the trophy icon path from the ShadPS4 installation.
-        /// Icon caching is handled by DiskImageService via RefreshRuntime.
-        /// </summary>
-        private string GetTrophyIconPath(string iconsFolder, string trophyId)
-        {
-            if (string.IsNullOrWhiteSpace(trophyId))
-            {
-                return null;
-            }
-
-            try
-            {
-                // Trophy icons follow TROP###.PNG format with zero-padded ID
-                var iconFileName = $"TROP{trophyId.PadLeft(3, '0')}.PNG";
-                var iconPath = Path.Combine(iconsFolder, iconFileName);
-
-                if (File.Exists(iconPath))
-                {
-                    return iconPath;
-                }
-
-                return null;
-            }
-            catch (Exception)
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Gets a localized element value from a trophy element.
-        /// Tries to find an element with matching lang attribute, falls back to element without lang.
-        /// </summary>
-        private static string GetLocalizedElement(XElement trophyElement, string elementName, string language)
-        {
-            if (string.IsNullOrWhiteSpace(language))
-            {
-                // No language specified, return first element found
-                return trophyElement.Element(elementName)?.Value;
-            }
-
-            // Try to find element with matching lang attribute
-            var localizedElement = trophyElement.Elements(elementName)
-                .FirstOrDefault(e => string.Equals(e.Attribute("lang")?.Value, language, StringComparison.OrdinalIgnoreCase));
-
-            if (localizedElement != null)
-            {
-                return localizedElement.Value;
-            }
-
-            // Fall back to element without lang attribute (default language)
-            var defaultElement = trophyElement.Elements(elementName)
-                .FirstOrDefault(e => e.Attribute("lang") == null);
-
-            return defaultElement?.Value ?? trophyElement.Element(elementName)?.Value;
-        }
-
-        /// <summary>
-        /// Maps a global language setting to PS4 locale code.
-        /// </summary>
-        private static string MapGlobalLanguageToPs4Locale(string globalLanguage)
-        {
-            if (string.IsNullOrWhiteSpace(globalLanguage))
-            {
-                return null;
-            }
-
-            var normalized = globalLanguage.Trim().ToLowerInvariant();
-
-            return normalized switch
-            {
-                "english" => "en",
-                "french" => "fr",
-                "spanish" => "es",
-                "german" => "de",
-                "italian" => "it",
-                "japanese" => "ja",
-                "dutch" => "nl",
-                "portuguese" => "pt",
-                "russian" => "ru",
-                "korean" => "ko",
-                "chinese" => "zh",
-                "polish" => "pl",
-                "danish" => "da",
-                "finnish" => "fi",
-                "norwegian" => "no",
-                "swedish" => "sv",
-                "turkish" => "tr",
-                "czech" => "cs",
-                "hungarian" => "hu",
-                "greek" => "el",
-                "brazilian" => "pt-br",
-                "latam" => "es-419",
-                _ => null
-            };
-        }
+        #endregion
     }
 }

--- a/source/Providers/ShadPS4/ShadPS4SettingsView.xaml.cs
+++ b/source/Providers/ShadPS4/ShadPS4SettingsView.xaml.cs
@@ -84,19 +84,56 @@ namespace PlayniteAchievements.Providers.ShadPS4
 
         private void CheckShadPS4Auth()
         {
+            // Check old-format path
             var gameDataPath = _shadps4Settings?.GameDataPath;
+            if (!string.IsNullOrWhiteSpace(gameDataPath) && System.IO.Directory.Exists(gameDataPath))
+            {
+                SetAuthenticated(true);
+                SetAuthStatusByKey("LOCPlayAch_Status_Succeeded");
+                return;
+            }
+
+            // Check new-format AppData path
+            try
+            {
+                var appData = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData);
+                var shadps4Path = System.IO.Path.Combine(appData, "shadPS4");
+                if (System.IO.Directory.Exists(shadps4Path))
+                {
+                    // Look for any user trophy directory
+                    var homePath = System.IO.Path.Combine(shadps4Path, "home");
+                    if (System.IO.Directory.Exists(homePath))
+                    {
+                        foreach (var userDir in System.IO.Directory.GetDirectories(homePath))
+                        {
+                            var trophyPath = System.IO.Path.Combine(userDir, "trophy");
+                            if (System.IO.Directory.Exists(trophyPath) &&
+                                System.IO.Directory.GetFiles(trophyPath, "*.xml").Length > 0)
+                            {
+                                SetAuthenticated(true);
+                                SetAuthStatusByKey("LOCPlayAch_Status_Succeeded");
+                                return;
+                            }
+                        }
+                    }
+
+                    // Also check if trophy base directory exists
+                    var trophyBasePath = System.IO.Path.Combine(shadps4Path, "trophy");
+                    if (System.IO.Directory.Exists(trophyBasePath) &&
+                        System.IO.Directory.GetDirectories(trophyBasePath).Length > 0)
+                    {
+                        SetAuthenticated(true);
+                        SetAuthStatusByKey("LOCPlayAch_Status_Succeeded");
+                        return;
+                    }
+                }
+            }
+            catch { }
 
             if (string.IsNullOrWhiteSpace(gameDataPath))
             {
                 SetAuthenticated(false);
                 SetAuthStatus(string.Format(ResourceProvider.GetString("LOCPlayAch_Settings_NotConfigured"), ResourceProvider.GetString("LOCPlayAch_Provider_ShadPS4")));
-                return;
-            }
-
-            if (System.IO.Directory.Exists(gameDataPath))
-            {
-                SetAuthenticated(true);
-                SetAuthStatusByKey("LOCPlayAch_Status_Succeeded");
             }
             else
             {

--- a/source/Views/SettingsControl.xaml
+++ b/source/Views/SettingsControl.xaml
@@ -1029,7 +1029,7 @@
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto"/>
-                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
                                                 <ColumnDefinition Width="Auto"/>
                                             </Grid.ColumnDefinitions>
                                             <TextBlock Grid.Column="0"
@@ -1043,26 +1043,24 @@
                                                 <ComboBoxItem Content="{DynamicResource LOCPlayAch_Common_UnlockTime}" Tag="{x:Static settings:CompactListSortMode.UnlockTime}"/>
                                                 <ComboBoxItem Content="{DynamicResource LOCPlayAch_Column_Rarity}" Tag="{x:Static settings:CompactListSortMode.Rarity}"/>
                                             </ComboBox>
-                                            <CheckBox Grid.Column="2"
-                                                      IsChecked="{Binding Persisted.CompactListSortDescending, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                      ToolTip="{DynamicResource LOCPlayAch_Settings_SortDirection_Tooltip}"
-                                                      Margin="4,0,0,0"
-                                                      VerticalAlignment="Center">
-                                                <CheckBox.Content>
-                                                    <TextBlock FontFamily="{DynamicResource CommonFont}" FontSize="14">
-                                                        <TextBlock.Style>
-                                                            <Style TargetType="TextBlock">
-                                                                <Setter Property="Text" Value="&#xea65;"/>
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding Persisted.CompactListSortDescending}" Value="True">
-                                                                        <Setter Property="Text" Value="&#xea66;"/>
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </TextBlock.Style>
-                                                    </TextBlock>
-                                                </CheckBox.Content>
-                                            </CheckBox>
+                                            <Button Grid.Column="2"
+                                                    ToolTip="{DynamicResource LOCPlayAch_Settings_SortDirection_Tooltip}"
+                                                    Margin="4,0,0,0"
+                                                    VerticalAlignment="Center"
+                                                    Click="ToggleCompactListSortDescending">
+                                                <TextBlock FontFamily="{DynamicResource CommonFont}" FontSize="18">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Text" Value="&#xea65;"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding Persisted.CompactListSortDescending}" Value="True">
+                                                                    <Setter Property="Text" Value="&#xea66;"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </Button>
                                         </Grid>
                                     </StackPanel>
                                 </Border>
@@ -1143,7 +1141,7 @@
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto"/>
-                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
                                                 <ColumnDefinition Width="Auto"/>
                                             </Grid.ColumnDefinitions>
                                             <TextBlock Grid.Column="0"
@@ -1157,26 +1155,24 @@
                                                 <ComboBoxItem Content="{DynamicResource LOCPlayAch_Common_UnlockTime}" Tag="{x:Static settings:CompactListSortMode.UnlockTime}"/>
                                                 <ComboBoxItem Content="{DynamicResource LOCPlayAch_Column_Rarity}" Tag="{x:Static settings:CompactListSortMode.Rarity}"/>
                                             </ComboBox>
-                                            <CheckBox Grid.Column="2"
-                                                      IsChecked="{Binding Persisted.CompactUnlockedListSortDescending, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                      ToolTip="{DynamicResource LOCPlayAch_Settings_SortDirection_Tooltip}"
-                                                      Margin="4,0,0,0"
-                                                      VerticalAlignment="Center">
-                                                <CheckBox.Content>
-                                                    <TextBlock FontFamily="{DynamicResource CommonFont}" FontSize="14">
-                                                        <TextBlock.Style>
-                                                            <Style TargetType="TextBlock">
-                                                                <Setter Property="Text" Value="&#xea65;"/>
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding Persisted.CompactUnlockedListSortDescending}" Value="True">
-                                                                        <Setter Property="Text" Value="&#xea66;"/>
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </TextBlock.Style>
-                                                    </TextBlock>
-                                                </CheckBox.Content>
-                                            </CheckBox>
+                                            <Button Grid.Column="2"
+                                                    ToolTip="{DynamicResource LOCPlayAch_Settings_SortDirection_Tooltip}"
+                                                    Margin="4,0,0,0"
+                                                    VerticalAlignment="Center"
+                                                    Click="ToggleCompactUnlockedListSortDescending">
+                                                <TextBlock FontFamily="{DynamicResource CommonFont}" FontSize="18">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Text" Value="&#xea65;"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding Persisted.CompactUnlockedListSortDescending}" Value="True">
+                                                                    <Setter Property="Text" Value="&#xea66;"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </Button>
                                         </Grid>
                                     </StackPanel>
                                 </Border>
@@ -1215,7 +1211,7 @@
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto"/>
-                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
                                                 <ColumnDefinition Width="Auto"/>
                                             </Grid.ColumnDefinitions>
                                             <TextBlock Grid.Column="0"
@@ -1229,26 +1225,24 @@
                                                 <ComboBoxItem Content="{DynamicResource LOCPlayAch_Common_UnlockTime}" Tag="{x:Static settings:CompactListSortMode.UnlockTime}"/>
                                                 <ComboBoxItem Content="{DynamicResource LOCPlayAch_Column_Rarity}" Tag="{x:Static settings:CompactListSortMode.Rarity}"/>
                                             </ComboBox>
-                                            <CheckBox Grid.Column="2"
-                                                      IsChecked="{Binding Persisted.CompactLockedListSortDescending, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                      ToolTip="{DynamicResource LOCPlayAch_Settings_SortDirection_Tooltip}"
-                                                      Margin="4,0,0,0"
-                                                      VerticalAlignment="Center">
-                                                <CheckBox.Content>
-                                                    <TextBlock FontFamily="{DynamicResource CommonFont}" FontSize="14">
-                                                        <TextBlock.Style>
-                                                            <Style TargetType="TextBlock">
-                                                                <Setter Property="Text" Value="&#xea65;"/>
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding Persisted.CompactLockedListSortDescending}" Value="True">
-                                                                        <Setter Property="Text" Value="&#xea66;"/>
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </TextBlock.Style>
-                                                    </TextBlock>
-                                                </CheckBox.Content>
-                                            </CheckBox>
+                                            <Button Grid.Column="2"
+                                                    ToolTip="{DynamicResource LOCPlayAch_Settings_SortDirection_Tooltip}"
+                                                    Margin="4,0,0,0"
+                                                    VerticalAlignment="Center"
+                                                    Click="ToggleCompactLockedListSortDescending">
+                                                <TextBlock FontFamily="{DynamicResource CommonFont}" FontSize="18">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Text" Value="&#xea65;"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding Persisted.CompactLockedListSortDescending}" Value="True">
+                                                                    <Setter Property="Text" Value="&#xea66;"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </Button>
                                         </Grid>
                                     </StackPanel>
                                 </Border>

--- a/source/Views/SettingsControl.xaml.cs
+++ b/source/Views/SettingsControl.xaml.cs
@@ -1200,6 +1200,37 @@ namespace PlayniteAchievements.Views
         }
 
         // -----------------------------
+        // Compact list sort direction toggles
+        // -----------------------------
+
+        private void ToggleCompactListSortDescending(object sender, RoutedEventArgs e)
+        {
+            var persisted = _settingsViewModel?.Settings?.Persisted;
+            if (persisted != null)
+            {
+                persisted.CompactListSortDescending = !persisted.CompactListSortDescending;
+            }
+        }
+
+        private void ToggleCompactUnlockedListSortDescending(object sender, RoutedEventArgs e)
+        {
+            var persisted = _settingsViewModel?.Settings?.Persisted;
+            if (persisted != null)
+            {
+                persisted.CompactUnlockedListSortDescending = !persisted.CompactUnlockedListSortDescending;
+            }
+        }
+
+        private void ToggleCompactLockedListSortDescending(object sender, RoutedEventArgs e)
+        {
+            var persisted = _settingsViewModel?.Settings?.Persisted;
+            if (persisted != null)
+            {
+                persisted.CompactLockedListSortDescending = !persisted.CompactLockedListSortDescending;
+            }
+        }
+
+        // -----------------------------
         // Tagging Methods
         // -----------------------------
 


### PR DESCRIPTION
shadPS4 recently moved trophy storage from the emulator install directory to `%APPDATA%\shadPS4\`. The new layout organizes data by npcommid instead of title ID, with per-user unlock state in `home/{userId}/trophy/{npcommid}.xml` and shared metadata/icons in `trophy/{npcommid}/`.

To map Playnite games to their trophy data, we parse each game's `sce_sys/npbind.dat` binary file to extract the npcommid. The old `user/game_data` format still works as a fallback.

Changes:
- `ShadPS4DataProvider`: AppData path auto-discovery, npcommid cache, npbind.dat parsing
- `ShadPS4Scanner`: New-format XML parsing with `unlockstate="true"/"false"` semantics and Unix timestamps
- `ShadPS4SettingsView`: Auth check recognizes both old and new path formats