### PR TITLE
fullscreen mode window support

### DIFF
--- a/source/Localization/LocSource.xaml
+++ b/source/Localization/LocSource.xaml
@@ -113,15 +113,6 @@
     <!-- ================================================================= -->
     <!-- 06 Menus -->
     <!-- ================================================================= -->
-    <sys:String x:Key="LOCPlayAch_Menu_ViewAchievements">View Achievements</sys:String>
-    <sys:String x:Key="LOCPlayAch_Menu_OpenOverview">Achievements Overview</sys:String>
-    <sys:String x:Key="LOCPlayAch_Menu_TestModernControls">Test Modern Theme Controls</sys:String>
-    <sys:String x:Key="LOCPlayAch_Menu_GameOptions">Game Options</sys:String>
-    <sys:String x:Key="LOCPlayAch_Menu_SetCapstone">Set Capstone Achievement</sys:String>
-    <sys:String x:Key="LOCPlayAch_Menu_RefreshGame">Refresh Single Game</sys:String>
-    <sys:String x:Key="LOCPlayAch_Menu_RefreshSelected">Refresh Selected Games</sys:String>
-    <sys:String x:Key="LOCPlayAch_Menu_RefreshInProgress">[Refresh in Progress]</sys:String>
-    <sys:String x:Key="LOCPlayAch_Menu_ViewRefreshProgress">View</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_ClearData">Clear Data</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_ClearData_ConfirmSelected">Clear data for {0} selected games?&#10;&#10;This removes cached achievements and icons for those games. Any manual tracking links and manual unlock times for those games will also be removed.</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_ClearData_ConfirmSingle">Clear data for "{0}"?&#10;&#10;This removes cached achievements and icons for this game. If the game has a manual tracking link, that link and its manual unlock times will also be removed.</sys:String>
@@ -136,11 +127,13 @@
     <sys:String x:Key="LOCPlayAch_Menu_IncludeInRefreshes">Include in Refreshes</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_IncludeInRefreshesAndRefresh">Include in Refreshes and Refresh Selected Games</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_OpenGameInLibrary">Open Game in Library</sys:String>
+    <sys:String x:Key="LOCPlayAch_Menu_OpenOverview">Achievements Overview</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_OpenGameInSidebar">Open Game in Sidebar</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_RaGameId_InvalidId">Please enter a valid positive integer game ID.</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_RefreshGame">Refresh Single Game</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_RefreshInProgress">[Refresh in Progress]</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_RefreshSelected">Refresh Selected Games</sys:String>
+    <sys:String x:Key="LOCPlayAch_Menu_SetCapstone">Set Capstone Achievement</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_TestModernControls">Test Modern Theme Controls</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_UnlinkAchievements">Unlink Achievements</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_UnlinkAchievements_Confirm">Unlink achievements for "{0}"?&#10;&#10;This will remove the manual achievement link, delete all manually set unlock times, and clear cached data for this game immediately.</sys:String>

--- a/source/Localization/LocSource.xaml
+++ b/source/Localization/LocSource.xaml
@@ -113,6 +113,15 @@
     <!-- ================================================================= -->
     <!-- 06 Menus -->
     <!-- ================================================================= -->
+    <sys:String x:Key="LOCPlayAch_Menu_ViewAchievements">View Achievements</sys:String>
+    <sys:String x:Key="LOCPlayAch_Menu_OpenOverview">Achievements Overview</sys:String>
+    <sys:String x:Key="LOCPlayAch_Menu_TestModernControls">Test Modern Theme Controls</sys:String>
+    <sys:String x:Key="LOCPlayAch_Menu_GameOptions">Game Options</sys:String>
+    <sys:String x:Key="LOCPlayAch_Menu_SetCapstone">Set Capstone Achievement</sys:String>
+    <sys:String x:Key="LOCPlayAch_Menu_RefreshGame">Refresh Single Game</sys:String>
+    <sys:String x:Key="LOCPlayAch_Menu_RefreshSelected">Refresh Selected Games</sys:String>
+    <sys:String x:Key="LOCPlayAch_Menu_RefreshInProgress">[Refresh in Progress]</sys:String>
+    <sys:String x:Key="LOCPlayAch_Menu_ViewRefreshProgress">View</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_ClearData">Clear Data</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_ClearData_ConfirmSelected">Clear data for {0} selected games?&#10;&#10;This removes cached achievements and icons for those games. Any manual tracking links and manual unlock times for those games will also be removed.</sys:String>
     <sys:String x:Key="LOCPlayAch_Menu_ClearData_ConfirmSingle">Clear data for "{0}"?&#10;&#10;This removes cached achievements and icons for this game. If the game has a manual tracking link, that link and its manual unlock times will also be removed.</sys:String>

--- a/source/PlayniteAchievementsPlugin.Menus.cs
+++ b/source/PlayniteAchievementsPlugin.Menus.cs
@@ -618,6 +618,33 @@ namespace PlayniteAchievements
 
             if (!refreshInProgress)
             {
+                // Fullscreen-only: overview window (desktop uses the sidebar panel).
+                var isFullscreen = false;
+                try
+                {
+                    isFullscreen = PlayniteApi?.ApplicationInfo?.Mode == ApplicationMode.Fullscreen;
+                }
+                catch { }
+
+                if (isFullscreen)
+                {
+                    yield return new MainMenuItem
+                    {
+                        Description = ResourceProvider.GetString("LOCPlayAch_Menu_OpenOverview"),
+                        MenuSection = PluginMainMenuSection,
+                        Action = (a) =>
+                        {
+                            OpenOverviewWindow();
+                        }
+                    };
+
+                    yield return new MainMenuItem
+                    {
+                        Description = "-",
+                        MenuSection = PluginMainMenuSection
+                    };
+                }
+
                 yield return new MainMenuItem
                 {
                     Description = ResourceProvider.GetString("LOCPlayAch_RefreshMode_Recent"),

--- a/source/PlayniteAchievementsPlugin.Windows.cs
+++ b/source/PlayniteAchievementsPlugin.Windows.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Threading.Tasks;
+using Playnite.SDK;
 using PlayniteAchievements.ViewModels;
+using PlayniteAchievements.Views;
+using PlayniteAchievements.Views.Helpers;
 
 namespace PlayniteAchievements
 {
@@ -49,6 +52,54 @@ namespace PlayniteAchievements
         private void EnsureAchievementResourcesLoaded()
         {
             _windowService.EnsureAchievementResourcesLoaded();
+        }
+
+        private void OpenOverviewWindow()
+        {
+            var view = new SidebarControl(
+                PlayniteApi, _logger, _refreshService, _cacheManager, PersistSettingsForUi,
+                _achievementOverridesService, _achievementDataService, _refreshCoordinator, _settingsViewModel.Settings);
+
+            var windowOptions = new WindowOptions
+            {
+                ShowMinimizeButton = false,
+                ShowMaximizeButton = true,
+                ShowCloseButton = true,
+                CanBeResizable = true,
+                Width = 1280,
+                Height = 800
+            };
+
+            var window = PlayniteUiProvider.CreateExtensionWindow(
+                ResourceProvider.GetString("LOCPlayAch_Menu_OpenOverview"),
+                view,
+                windowOptions,
+                isFullscreen: true);
+
+            try
+            {
+                if (window.Owner == null)
+                {
+                    window.Owner = PlayniteApi?.Dialogs?.GetCurrentAppWindow();
+                }
+            }
+            catch { }
+
+            window.Loaded += (s, e) => view.Activate();
+            window.Closed += (s, e) =>
+            {
+                view.Deactivate();
+                view.Dispose();
+            };
+
+            window.Show();
+            try
+            {
+                window.Topmost = true;
+                window.Activate();
+                window.Topmost = false;
+            }
+            catch { }
         }
 
         private enum ParityTestMode

--- a/source/PlayniteAchievementsPlugin.Windows.cs
+++ b/source/PlayniteAchievementsPlugin.Windows.cs
@@ -71,7 +71,7 @@ namespace PlayniteAchievements
             };
 
             var window = PlayniteUiProvider.CreateExtensionWindow(
-                ResourceProvider.GetString("LOCPlayAch_Menu_OpenOverview"),
+                string.Empty,
                 view,
                 windowOptions,
                 isFullscreen: true);

--- a/source/Providers/RetroAchievements/RetroAchievementsScanner.cs
+++ b/source/Providers/RetroAchievements/RetroAchievementsScanner.cs
@@ -613,7 +613,8 @@ namespace PlayniteAchievements.Providers.RetroAchievements
                     Points = ach.Points,
                     ScaledPoints = ach.TrueRatio,
                     Category = categoryLabel,
-                    IsCapstone = string.Equals(ach.Type, "win_condition", StringComparison.OrdinalIgnoreCase),
+                    // IsCapstone = string.Equals(ach.Type, "win_condition", StringComparison.OrdinalIgnoreCase),
+                    IsCapstone  = false,
                     UnlockTimeUtc = unlockUtc,
                     Hidden = false,
                     Rarity = globalPercent.HasValue

--- a/source/Resources/AchievementTemplates.xaml
+++ b/source/Resources/AchievementTemplates.xaml
@@ -225,13 +225,47 @@
            TargetType="MenuItem">
         <Style.Resources>
             <Style x:Key="AchievementSelectorMenuCheckBoxStyle"
-                   TargetType="CheckBox"
-                   BasedOn="{StaticResource {x:Type CheckBox}}">
+                   TargetType="CheckBox">
                 <Setter Property="Margin" Value="0"/>
                 <Setter Property="Focusable" Value="False"/>
                 <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
                 <Setter Property="HorizontalAlignment" Value="Left"/>
                 <Setter Property="VerticalAlignment" Value="Center"/>
+                <Setter Property="OverridesDefaultStyle" Value="True"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="CheckBox">
+                            <Border x:Name="CheckBoxBox"
+                                    Width="20" Height="20"
+                                    Background="{DynamicResource ControlBackgroundDarkBrush}"
+                                    BorderBrush="{DynamicResource SelectionLightBrush}"
+                                    BorderThickness="1.5"
+                                    CornerRadius="2"
+                                    SnapsToDevicePixels="True">
+                                <Viewbox Width="12" Height="12"
+                                         HorizontalAlignment="Center"
+                                         VerticalAlignment="Center">
+                                    <Path x:Name="CheckMark"
+                                          Data="M 1,5 L 5,9 L 11,1"
+                                          Stroke="{DynamicResource TextBrush}"
+                                          StrokeThickness="2"
+                                          StrokeStartLineCap="Round"
+                                          StrokeEndLineCap="Round"
+                                          Visibility="Collapsed"/>
+                                </Viewbox>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter TargetName="CheckMark" Property="Visibility" Value="Visible"/>
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="CheckBoxBox" Property="BorderBrush"
+                                            Value="{DynamicResource HighlightGlyphBrush}"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
             </Style>
         </Style.Resources>
         <Setter Property="OverridesDefaultStyle" Value="True"/>

--- a/source/Resources/AchievementTemplates.xaml
+++ b/source/Resources/AchievementTemplates.xaml
@@ -235,25 +235,29 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="CheckBox">
-                            <Border x:Name="CheckBoxBox"
-                                    Width="20" Height="20"
-                                    Background="{DynamicResource ControlBackgroundDarkBrush}"
-                                    BorderBrush="{DynamicResource SelectionLightBrush}"
-                                    BorderThickness="1.5"
-                                    CornerRadius="2"
-                                    SnapsToDevicePixels="True">
-                                <Viewbox Width="12" Height="12"
-                                         HorizontalAlignment="Center"
-                                         VerticalAlignment="Center">
-                                    <Path x:Name="CheckMark"
-                                          Data="M 1,5 L 5,9 L 11,1"
-                                          Stroke="{DynamicResource TextBrush}"
-                                          StrokeThickness="2"
-                                          StrokeStartLineCap="Round"
-                                          StrokeEndLineCap="Round"
-                                          Visibility="Collapsed"/>
-                                </Viewbox>
-                            </Border>
+                            <Grid Background="Transparent">
+                                <Border x:Name="CheckBoxBox"
+                                        Width="20" Height="20"
+                                        Background="Transparent"
+                                        BorderBrush="{DynamicResource SelectionLightBrush}"
+                                        BorderThickness="1.5"
+                                        CornerRadius="2"
+                                        SnapsToDevicePixels="True"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center">
+                                    <Viewbox Width="12" Height="12"
+                                             HorizontalAlignment="Center"
+                                             VerticalAlignment="Center">
+                                        <Path x:Name="CheckMark"
+                                              Data="M 1,5 L 5,9 L 11,1"
+                                              Stroke="{DynamicResource TextBrush}"
+                                              StrokeThickness="2"
+                                              StrokeStartLineCap="Round"
+                                              StrokeEndLineCap="Round"
+                                              Visibility="Collapsed"/>
+                                    </Viewbox>
+                                </Border>
+                            </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsChecked" Value="True">
                                     <Setter TargetName="CheckMark" Property="Visibility" Value="Visible"/>

--- a/source/Resources/AchievementTemplates.xaml
+++ b/source/Resources/AchievementTemplates.xaml
@@ -16,6 +16,10 @@
     <converters:PercentToRarityGlowConverter x:Key="PercentToRarityGlow"/>
     <converters:DefaultGameImageConverter x:Key="DefaultGameImage"/>
 
+    <!-- Menu highlight brush used by AchievementMultiSelectMenuItemStyle.
+         Overridden in FullscreenResources.xaml for dark backgrounds. -->
+    <SolidColorBrush x:Key="MenuHighlightBrush" Color="#14000000" />
+
     <!-- =======================
          DATAGRID STYLES
          ======================= -->
@@ -280,7 +284,7 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsHighlighted" Value="True">
-                            <Setter TargetName="MenuItemBorder" Property="Background" Value="#14000000"/>
+                            <Setter TargetName="MenuItemBorder" Property="Background" Value="{DynamicResource MenuHighlightBrush}"/>
                             <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">

--- a/source/Resources/FullscreenResources.xaml
+++ b/source/Resources/FullscreenResources.xaml
@@ -72,4 +72,81 @@
         </Style.Triggers>
     </Style>
 
+    <!-- ContextMenu background for fullscreen. -->
+    <Style TargetType="ContextMenu">
+        <Setter Property="Background" Value="{DynamicResource ControlBackgroundDarkBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource SelectionLightBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Padding" Value="2" />
+    </Style>
+
+    <!-- Popup background for fullscreen (ContextMenu uses Popup internally). -->
+    <Style TargetType="Popup">
+        <Setter Property="PopupAnimation" Value="Fade" />
+    </Style>
+
+    <!-- CheckBox style for fullscreen with adequate sizing.
+         Default WPF CheckBox is tiny at fullscreen font sizes (22px). -->
+    <Style TargetType="CheckBox">
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Padding" Value="6,4" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="CheckBox">
+                    <BulletDecorator Background="Transparent"
+                                     VerticalAlignment="{TemplateBinding VerticalAlignment}">
+                        <BulletDecorator.Bullet>
+                            <Border x:Name="CheckBoxBorder"
+                                    Width="22" Height="22"
+                                    Background="{DynamicResource ControlBackgroundDarkBrush}"
+                                    BorderBrush="{DynamicResource SelectionLightBrush}"
+                                    BorderThickness="1.5"
+                                    CornerRadius="2">
+                                <Path x:Name="CheckMark"
+                                      Data="M 4,8 L 8,12 L 16,4"
+                                      Stroke="{DynamicResource TextBrush}"
+                                      StrokeThickness="2"
+                                      StrokeStartLineCap="Round"
+                                      StrokeEndLineCap="Round"
+                                      Visibility="Collapsed"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center" />
+                            </Border>
+                        </BulletDecorator.Bullet>
+                        <ContentPresenter Margin="8,0,0,0"
+                                          HorizontalAlignment="Left"
+                                          VerticalAlignment="Center"
+                                          RecognizesAccessKey="True" />
+                    </BulletDecorator>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="CheckMark" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="CheckBoxBorder" Property="BorderBrush"
+                                    Value="{DynamicResource HighlightGlyphBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Style>
+    </Style>
+
+    <!-- ListBoxItem selection override for fullscreen visibility. -->
+    <Style TargetType="ListBoxItem">
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Padding" Value="4,2" />
+        <Style.Triggers>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" Value="#20EC6200" />
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="#15EC6200" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
 </ResourceDictionary>

--- a/source/Resources/FullscreenResources.xaml
+++ b/source/Resources/FullscreenResources.xaml
@@ -1,0 +1,34 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- Fallback resources for desktop-only keys used by the plugin.
+         Merged into popup windows when running in Playnite fullscreen mode,
+         where the default theme does not define these keys. -->
+
+    <SolidColorBrush x:Key="NormalBorderBrush" Color="#FF8D919D" />
+    <SolidColorBrush x:Key="HighlightGlyphBrush" Color="#FFEC6200" />
+    <SolidColorBrush x:Key="NormalBrush" Color="#FF8D919D" />
+    <SolidColorBrush x:Key="TextBrushDarker" Color="#FF757575" />
+    <SolidColorBrush x:Key="PopupBackgroundBrush" Color="#FF121830" />
+
+    <sys:Double x:Key="FontSizeLarge">28</sys:Double>
+
+    <Style x:Key="BaseTextBlockStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="{DynamicResource FontSize}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+    </Style>
+
+    <Style x:Key="SearchTextBoxStyle" TargetType="TextBox">
+        <Setter Property="Background" Value="{DynamicResource ControlBackgroundDarkBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource SelectionLightBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Padding" Value="6,4" />
+        <Setter Property="FontSize" Value="{DynamicResource FontSize}" />
+        <Setter Property="CaretBrush" Value="{DynamicResource TextBrush}" />
+    </Style>
+
+    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+
+</ResourceDictionary>

--- a/source/Resources/FullscreenResources.xaml
+++ b/source/Resources/FullscreenResources.xaml
@@ -135,7 +135,7 @@
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
-        </Style>
+        </Setter>
     </Style>
 
     <!-- ListBoxItem selection override for fullscreen visibility. -->

--- a/source/Resources/FullscreenResources.xaml
+++ b/source/Resources/FullscreenResources.xaml
@@ -31,4 +31,45 @@
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
+    <!-- DataGrid selection overrides for fullscreen visibility.
+         The default #40FFFFFF white overlays are invisible on dark backgrounds. -->
+    <Style TargetType="DataGridCell">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Style.Triggers>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" Value="#25EC6200" />
+            </Trigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsMouseOver" Value="True" />
+                    <Condition Property="IsSelected" Value="True" />
+                </MultiTrigger.Conditions>
+                <Setter Property="Background" Value="#35EC6200" />
+            </MultiTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="DataGridRow">
+        <Setter Property="Background" Value="Transparent" />
+        <Style.Triggers>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" Value="#18EC6200" />
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="#10EC6200" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <!-- MenuItem selection override for fullscreen visibility. -->
+    <Style TargetType="MenuItem">
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter Property="Background" Value="#20EC6200" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
 </ResourceDictionary>

--- a/source/Resources/FullscreenResources.xaml
+++ b/source/Resources/FullscreenResources.xaml
@@ -31,6 +31,10 @@
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
+    <!-- Override menu highlight for dark fullscreen backgrounds.
+         Desktop uses #14000000 which is invisible on dark backgrounds. -->
+    <SolidColorBrush x:Key="MenuHighlightBrush" Color="#25EC6200" />
+
     <!-- DataGrid selection overrides for fullscreen visibility.
          The default #40FFFFFF white overlays are invisible on dark backgrounds. -->
     <Style TargetType="DataGridCell">

--- a/source/Resources/FullscreenResources.xaml
+++ b/source/Resources/FullscreenResources.xaml
@@ -76,12 +76,27 @@
         </Style.Triggers>
     </Style>
 
-    <!-- ContextMenu background for fullscreen. -->
+    <!-- ContextMenu template override for fullscreen dark background.
+         Default ContextMenu popup has white chrome that bleeds through. -->
     <Style TargetType="ContextMenu">
         <Setter Property="Background" Value="{DynamicResource ControlBackgroundDarkBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource SelectionLightBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Padding" Value="2" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ContextMenu">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="3"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <ItemsPresenter />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!-- Popup background for fullscreen (ContextMenu uses Popup internally). -->

--- a/source/Resources/FullscreenResources.xaml
+++ b/source/Resources/FullscreenResources.xaml
@@ -89,61 +89,9 @@
         <Setter Property="PopupAnimation" Value="Fade" />
     </Style>
 
-    <!-- CheckBox style for fullscreen with adequate sizing.
-         Default WPF CheckBox is tiny at fullscreen font sizes (22px).
-         Uses x:Key so it does NOT override the internal checkbox in AchievementMultiSelectMenuItemStyle. -->
-    <Style x:Key="FullscreenCheckBoxStyle" TargetType="CheckBox">
-        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
-        <Setter Property="Background" Value="Transparent" />
-        <Setter Property="VerticalAlignment" Value="Center" />
-        <Setter Property="Padding" Value="6,4" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="CheckBox">
-                    <BulletDecorator Background="Transparent"
-                                     VerticalAlignment="{TemplateBinding VerticalAlignment}">
-                        <BulletDecorator.Bullet>
-                            <Border x:Name="CheckBoxBorder"
-                                    Width="22" Height="22"
-                                    Background="{DynamicResource ControlBackgroundDarkBrush}"
-                                    BorderBrush="{DynamicResource SelectionLightBrush}"
-                                    BorderThickness="1.5"
-                                    CornerRadius="2"
-                                    SnapsToDevicePixels="True">
-                                <Viewbox Width="14" Height="14"
-                                         HorizontalAlignment="Center"
-                                         VerticalAlignment="Center">
-                                    <Path x:Name="CheckMark"
-                                          Data="M 1,5 L 5,9 L 11,1"
-                                          Stroke="{DynamicResource TextBrush}"
-                                          StrokeThickness="2"
-                                          StrokeStartLineCap="Round"
-                                          StrokeEndLineCap="Round"
-                                          Visibility="Collapsed" />
-                                </Viewbox>
-                            </Border>
-                        </BulletDecorator.Bullet>
-                        <ContentPresenter Margin="8,0,0,0"
-                                          HorizontalAlignment="Left"
-                                          VerticalAlignment="Center"
-                                          RecognizesAccessKey="True" />
-                    </BulletDecorator>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsChecked" Value="True">
-                            <Setter TargetName="CheckMark" Property="Visibility" Value="Visible" />
-                        </Trigger>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="CheckBoxBorder" Property="BorderBrush"
-                                    Value="{DynamicResource HighlightGlyphBrush}" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
     <!-- Default implicit CheckBox style for fullscreen - lightweight, no custom template.
-         Only overrides colors/sizing, keeps default WPF rendering for the checkmark. -->
+         Only overrides colors/sizing, keeps default WPF rendering for the checkmark.
+         Menu item checkboxes use their own template via AchievementSelectorMenuCheckBoxStyle. -->
     <Style TargetType="CheckBox">
         <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
         <Setter Property="Background" Value="Transparent" />

--- a/source/Resources/FullscreenResources.xaml
+++ b/source/Resources/FullscreenResources.xaml
@@ -90,8 +90,9 @@
     </Style>
 
     <!-- CheckBox style for fullscreen with adequate sizing.
-         Default WPF CheckBox is tiny at fullscreen font sizes (22px). -->
-    <Style TargetType="CheckBox">
+         Default WPF CheckBox is tiny at fullscreen font sizes (22px).
+         Uses x:Key so it does NOT override the internal checkbox in AchievementMultiSelectMenuItemStyle. -->
+    <Style x:Key="FullscreenCheckBoxStyle" TargetType="CheckBox">
         <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="VerticalAlignment" Value="Center" />
@@ -107,16 +108,19 @@
                                     Background="{DynamicResource ControlBackgroundDarkBrush}"
                                     BorderBrush="{DynamicResource SelectionLightBrush}"
                                     BorderThickness="1.5"
-                                    CornerRadius="2">
-                                <Path x:Name="CheckMark"
-                                      Data="M 4,8 L 8,12 L 16,4"
-                                      Stroke="{DynamicResource TextBrush}"
-                                      StrokeThickness="2"
-                                      StrokeStartLineCap="Round"
-                                      StrokeEndLineCap="Round"
-                                      Visibility="Collapsed"
-                                      HorizontalAlignment="Center"
-                                      VerticalAlignment="Center" />
+                                    CornerRadius="2"
+                                    SnapsToDevicePixels="True">
+                                <Viewbox Width="14" Height="14"
+                                         HorizontalAlignment="Center"
+                                         VerticalAlignment="Center">
+                                    <Path x:Name="CheckMark"
+                                          Data="M 1,5 L 5,9 L 11,1"
+                                          Stroke="{DynamicResource TextBrush}"
+                                          StrokeThickness="2"
+                                          StrokeStartLineCap="Round"
+                                          StrokeEndLineCap="Round"
+                                          Visibility="Collapsed" />
+                                </Viewbox>
                             </Border>
                         </BulletDecorator.Bullet>
                         <ContentPresenter Margin="8,0,0,0"
@@ -136,6 +140,21 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+    </Style>
+
+    <!-- Default implicit CheckBox style for fullscreen - lightweight, no custom template.
+         Only overrides colors/sizing, keeps default WPF rendering for the checkmark. -->
+    <Style TargetType="CheckBox">
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="{DynamicResource SelectionLightBrush}" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Padding" Value="6,4" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="BorderBrush" Value="{DynamicResource HighlightGlyphBrush}" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <!-- ListBoxItem selection override for fullscreen visibility. -->

--- a/source/Services/UI/PluginWindowService.cs
+++ b/source/Services/UI/PluginWindowService.cs
@@ -56,6 +56,41 @@ namespace PlayniteAchievements.Services.UI
             _ensureAchievementResourcesLoaded = ensureAchievementResourcesLoaded;
         }
 
+        private bool DetectFullscreenMode()
+        {
+            try
+            {
+                return _api?.ApplicationInfo?.Mode == ApplicationMode.Fullscreen;
+            }
+            catch (Exception ex)
+            {
+                _logger?.Debug(ex, "Failed to check fullscreen mode");
+                return false;
+            }
+        }
+
+        private void ShowWindow(Window window, bool isFullscreen)
+        {
+            if (isFullscreen)
+            {
+                window.Show();
+                try
+                {
+                    window.Topmost = true;
+                    window.Activate();
+                    window.Topmost = false;
+                }
+                catch (Exception ex)
+                {
+                    _logger?.Debug(ex, "Failed to activate window in fullscreen");
+                }
+            }
+            else
+            {
+                window.ShowDialog();
+            }
+        }
+
         public void ShowRefreshProgressControlAndRun(Func<Task> refreshTask, Action<Guid> openSingleGameAchievementsView, Guid? singleGameRefreshId = null)
         {
             ShowRefreshProgressControl(singleGameRefreshId, refreshTask, openSingleGameAchievementsView, validateCanStart: false);
@@ -85,6 +120,8 @@ namespace PlayniteAchievements.Services.UI
             Func<Task> refreshTask,
             Action<Guid> openSingleGameAchievementsView)
         {
+            var isFullscreen = DetectFullscreenMode();
+
             var progressWindow = new RefreshProgressControl(
                 _refreshService,
                 _logger,
@@ -104,7 +141,8 @@ namespace PlayniteAchievements.Services.UI
             var window = PlayniteUiProvider.CreateExtensionWindow(
                 progressWindow.WindowTitle,
                 progressWindow,
-                windowOptions
+                windowOptions,
+                isFullscreen
             );
 
             try
@@ -129,16 +167,6 @@ namespace PlayniteAchievements.Services.UI
                 }
             };
 
-            var isFullscreen = false;
-            try
-            {
-                isFullscreen = _api?.ApplicationInfo?.Mode == ApplicationMode.Fullscreen;
-            }
-            catch (Exception ex)
-            {
-                _logger?.Debug(ex, "Failed to check fullscreen mode");
-            }
-
             if (refreshTask != null)
             {
                 Task.Run(async () =>
@@ -154,24 +182,7 @@ namespace PlayniteAchievements.Services.UI
                 });
             }
 
-            if (isFullscreen)
-            {
-                window.Show();
-                try
-                {
-                    window.Topmost = true;
-                    window.Activate();
-                    window.Topmost = false;
-                }
-                catch (Exception ex)
-                {
-                    _logger?.Debug(ex, "Failed to activate window in fullscreen");
-                }
-            }
-            else
-            {
-                window.ShowDialog();
-            }
+            ShowWindow(window, isFullscreen);
         }
 
         private void InvokeOnUiThread(Action action)
@@ -201,6 +212,8 @@ namespace PlayniteAchievements.Services.UI
         {
             try
             {
+                var isFullscreen = DetectFullscreenMode();
+
                 var view = new SingleGameControl(
                     gameId,
                     _refreshService,
@@ -222,7 +235,8 @@ namespace PlayniteAchievements.Services.UI
                 var window = PlayniteUiProvider.CreateExtensionWindow(
                     view.WindowTitle,
                     view,
-                    windowOptions
+                    windowOptions,
+                    isFullscreen
                 );
 
                 window.MinWidth = 450;
@@ -240,33 +254,7 @@ namespace PlayniteAchievements.Services.UI
 
                 window.Closed += (s, ev) => view.Cleanup();
 
-                var isFullscreen = false;
-                try
-                {
-                    isFullscreen = _api?.ApplicationInfo?.Mode == ApplicationMode.Fullscreen;
-                }
-                catch (Exception ex)
-                {
-                    _logger?.Debug(ex, "Failed to check fullscreen mode");
-                }
-
-                if (isFullscreen)
-                {
-                    window.Show();
-                    try
-                    {
-                        window.Topmost = true;
-                        window.Activate();
-                        window.Topmost = false;
-                    }
-                    catch
-                    {
-                    }
-                }
-                else
-                {
-                    window.ShowDialog();
-                }
+                ShowWindow(window, isFullscreen);
             }
             catch (Exception ex)
             {
@@ -334,6 +322,8 @@ namespace PlayniteAchievements.Services.UI
         {
             try
             {
+                var isFullscreen = DetectFullscreenMode();
+
                 var game = _api?.Database?.Games?.Get(gameId);
                 if (game == null)
                 {
@@ -371,7 +361,8 @@ namespace PlayniteAchievements.Services.UI
                 var window = PlayniteUiProvider.CreateExtensionWindow(
                     view.WindowTitle,
                     view,
-                    windowOptions);
+                    windowOptions,
+                    isFullscreen);
 
                 window.MinWidth = 860;
                 window.MinHeight = 620;
@@ -388,34 +379,7 @@ namespace PlayniteAchievements.Services.UI
 
                 window.Closed += (s, e) => view.Cleanup();
 
-                var isFullscreen = false;
-                try
-                {
-                    isFullscreen = _api?.ApplicationInfo?.Mode == ApplicationMode.Fullscreen;
-                }
-                catch (Exception ex)
-                {
-                    _logger?.Debug(ex, "Failed to check fullscreen mode");
-                }
-
-                if (isFullscreen)
-                {
-                    window.Show();
-                    try
-                    {
-                        window.Topmost = true;
-                        window.Activate();
-                        window.Topmost = false;
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger?.Debug(ex, "Failed to activate Game Options window in fullscreen");
-                    }
-                }
-                else
-                {
-                    window.ShowDialog();
-                }
+                ShowWindow(window, isFullscreen);
             }
             catch (Exception ex)
             {
@@ -541,4 +505,3 @@ namespace PlayniteAchievements.Services.UI
         }
     }
 }
-

--- a/source/ViewModels/SidebarViewModel.cs
+++ b/source/ViewModels/SidebarViewModel.cs
@@ -172,7 +172,36 @@ namespace PlayniteAchievements.ViewModels
             OpenGameInLibraryCommand = new RelayCommand(OpenGameInLibrary);
             OpenGameInSidebarCommand = new RelayCommand(OpenGameInSidebar);
             RefreshSingleGameCommand = new AsyncCommand(ExecuteSingleGameRefreshAsync);
-            CloseViewCommand = new RelayCommand(_ => PlayniteUiProvider.RestoreMainView());
+            CloseViewCommand = new RelayCommand(_ =>
+            {
+                try
+                {
+                    if (_playniteApi?.ApplicationInfo?.Mode == ApplicationMode.Fullscreen)
+                    {
+                        System.Windows.Application.Current?.Dispatcher?.BeginInvoke(new Action(() =>
+                        {
+                            var window = System.Windows.Window.GetWindow(
+                                System.Windows.Application.Current?.MainWindow);
+                            // Walk up from any focused element to find our popup window
+                            var focused = System.Windows.Input.Keyboard.FocusedElement as System.Windows.DependencyObject;
+                            while (focused != null)
+                            {
+                                if (focused is System.Windows.Window w)
+                                {
+                                    window = w;
+                                    break;
+                                }
+                                focused = System.Windows.Media.VisualTreeHelper.GetParent(focused);
+                            }
+                            window?.Close();
+                        }));
+                        return;
+                    }
+                }
+                catch { }
+
+                PlayniteUiProvider.RestoreMainView();
+            });
             ClearGameSelectionCommand = new RelayCommand(_ => ClearGameSelection());
             NavigateToGameCommand = new RelayCommand(param => NavigateToGame(param as GameOverviewItem));
 

--- a/source/Views/Helpers/FullscreenOverlayContainer.xaml
+++ b/source/Views/Helpers/FullscreenOverlayContainer.xaml
@@ -1,0 +1,54 @@
+<UserControl x:Class="PlayniteAchievements.Views.Helpers.FullscreenOverlayContainer"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid Background="{DynamicResource OverlayBrush}">
+        <Border HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Background="{DynamicResource OverlayMenuBackgroundBrush}"
+                CornerRadius="3"
+                x:Name="ContentPanel">
+            <Border.Style>
+                <Style TargetType="Border">
+                    <Setter Property="Padding" Value="0" />
+                </Style>
+            </Border.Style>
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <!-- Title bar -->
+                <DockPanel Grid.Row="0"
+                           Margin="20,16,20,8"
+                           LastChildFill="True">
+                    <Button x:Name="CloseButton"
+                            DockPanel.Dock="Right"
+                            Width="60"
+                            Height="60"
+                            FontSize="30"
+                            FontWeight="Bold"
+                            Content="X"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            Cursor="Hand" />
+                    <TextBlock x:Name="TitleText"
+                               FontSize="26"
+                               FontWeight="Bold"
+                               Foreground="{DynamicResource TextBrush}"
+                               VerticalAlignment="Center"
+                               TextWrapping="NoWrap"
+                               TextTrimming="CharacterEllipsis" />
+                </DockPanel>
+
+                <!-- Content area -->
+                <ScrollViewer Grid.Row="1"
+                              VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled"
+                              KeyboardNavigation.DirectionalNavigation="Contained">
+                    <ContentPresenter x:Name="ContentHost" Margin="0" />
+                </ScrollViewer>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/source/Views/Helpers/FullscreenOverlayContainer.xaml
+++ b/source/Views/Helpers/FullscreenOverlayContainer.xaml
@@ -7,11 +7,6 @@
                 Background="{DynamicResource OverlayMenuBackgroundBrush}"
                 CornerRadius="3"
                 x:Name="ContentPanel">
-            <Border.Style>
-                <Style TargetType="Border">
-                    <Setter Property="Padding" Value="0" />
-                </Style>
-            </Border.Style>
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
@@ -41,13 +36,11 @@
                                TextTrimming="CharacterEllipsis" />
                 </DockPanel>
 
-                <!-- Content area -->
-                <ScrollViewer Grid.Row="1"
-                              VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled"
-                              KeyboardNavigation.DirectionalNavigation="Contained">
-                    <ContentPresenter x:Name="ContentHost" Margin="0" />
-                </ScrollViewer>
+                <!-- Content area: no outer ScrollViewer.
+                     Inner controls (DataGrid, tab content) handle their own scrolling. -->
+                <ContentPresenter x:Name="ContentHost"
+                                  Grid.Row="1"
+                                  Margin="12,0,12,12" />
             </Grid>
         </Border>
     </Grid>

--- a/source/Views/Helpers/FullscreenOverlayContainer.xaml
+++ b/source/Views/Helpers/FullscreenOverlayContainer.xaml
@@ -13,20 +13,12 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
 
-                <!-- Title bar -->
-                <DockPanel Grid.Row="0"
+                <!-- Title bar (collapsed when title is empty) -->
+                <DockPanel x:Name="TitleBar"
+                           Grid.Row="0"
                            Margin="16,10,16,6"
-                           LastChildFill="True">
-                    <Button x:Name="CloseButton"
-                            DockPanel.Dock="Right"
-                            Width="40"
-                            Height="40"
-                            FontSize="20"
-                            FontWeight="Bold"
-                            Content="X"
-                            HorizontalAlignment="Right"
-                            VerticalAlignment="Center"
-                            Cursor="Hand" />
+                           LastChildFill="True"
+                           Visibility="Collapsed">
                     <TextBlock x:Name="TitleText"
                                FontSize="18"
                                FontWeight="Bold"
@@ -36,12 +28,24 @@
                                TextTrimming="CharacterEllipsis" />
                 </DockPanel>
 
-                <!-- Content area: no outer ScrollViewer.
-                     Inner controls (DataGrid, tab content) handle their own scrolling. -->
+                <!-- Content area -->
                 <ContentPresenter x:Name="ContentHost"
                                   Grid.Row="1"
                                   Margin="12,0,12,12" />
             </Grid>
         </Border>
+
+        <!-- Floating close button (visible only when title is set) -->
+        <Button x:Name="CloseButton"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top"
+                Width="40"
+                Height="40"
+                Margin="0,8,20,0"
+                FontSize="20"
+                FontWeight="Bold"
+                Content="X"
+                Cursor="Hand"
+                Visibility="Collapsed" />
     </Grid>
 </UserControl>

--- a/source/Views/Helpers/FullscreenOverlayContainer.xaml
+++ b/source/Views/Helpers/FullscreenOverlayContainer.xaml
@@ -15,20 +15,20 @@
 
                 <!-- Title bar -->
                 <DockPanel Grid.Row="0"
-                           Margin="20,16,20,8"
+                           Margin="16,10,16,6"
                            LastChildFill="True">
                     <Button x:Name="CloseButton"
                             DockPanel.Dock="Right"
-                            Width="60"
-                            Height="60"
-                            FontSize="30"
+                            Width="40"
+                            Height="40"
+                            FontSize="20"
                             FontWeight="Bold"
                             Content="X"
                             HorizontalAlignment="Right"
-                            VerticalAlignment="Top"
+                            VerticalAlignment="Center"
                             Cursor="Hand" />
                     <TextBlock x:Name="TitleText"
-                               FontSize="26"
+                               FontSize="18"
                                FontWeight="Bold"
                                Foreground="{DynamicResource TextBrush}"
                                VerticalAlignment="Center"

--- a/source/Views/Helpers/FullscreenOverlayContainer.xaml.cs
+++ b/source/Views/Helpers/FullscreenOverlayContainer.xaml.cs
@@ -47,7 +47,13 @@ namespace PlayniteAchievements.Views.Helpers
             HostedContent = content;
         }
 
-        public void UpdatePanelSize()
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            ApplyFixedSize();
+            FocusInitialElement();
+        }
+
+        private void ApplyFixedSize()
         {
             var parent = Window.GetWindow(this);
             double availWidth = parent?.ActualWidth > 0 ? parent.ActualWidth : SystemParameters.PrimaryScreenWidth;
@@ -55,35 +61,34 @@ namespace PlayniteAchievements.Views.Helpers
 
             if (SizeMode == FullscreenSizeMode.Dialog)
             {
-                ContentPanel.MaxWidth = Math.Min(640, availWidth * 0.9);
-                ContentPanel.MaxHeight = Math.Min(400, availHeight * 0.9);
+                ContentPanel.Width = Math.Min(640, availWidth * 0.85);
+                ContentPanel.Height = Math.Min(400, availHeight * 0.85);
             }
             else
             {
-                ContentPanel.MaxWidth = availWidth * 0.92;
-                ContentPanel.MaxHeight = availHeight * 0.92;
+                ContentPanel.Width = availWidth * 0.92;
+                ContentPanel.Height = availHeight * 0.92;
             }
         }
 
-        private void OnLoaded(object sender, RoutedEventArgs e)
+        private void FocusInitialElement()
         {
-            UpdatePanelSize();
-
-            if (HostedContent != null)
+            if (HostedContent == null)
             {
-                var focusTarget = FindFirstFocusable(HostedContent);
-                if (focusTarget != null)
-                {
-                    FocusManager.SetFocusedElement(this, focusTarget);
-                    Keyboard.Focus(focusTarget);
-                }
+                return;
+            }
+
+            var focusTarget = FindFirstFocusable(HostedContent);
+            if (focusTarget != null)
+            {
+                FocusManager.SetFocusedElement(this, focusTarget);
+                Keyboard.Focus(focusTarget);
             }
         }
 
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
-            var window = Window.GetWindow(this);
-            window?.Close();
+            Window.GetWindow(this)?.Close();
         }
 
         private static void OnTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/source/Views/Helpers/FullscreenOverlayContainer.xaml.cs
+++ b/source/Views/Helpers/FullscreenOverlayContainer.xaml.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace PlayniteAchievements.Views.Helpers
+{
+    public enum FullscreenSizeMode
+    {
+        Fullscreen,
+        Dialog
+    }
+
+    public partial class FullscreenOverlayContainer : UserControl
+    {
+        public static readonly DependencyProperty TitleProperty =
+            DependencyProperty.Register(nameof(Title), typeof(string), typeof(FullscreenOverlayContainer),
+                new PropertyMetadata(string.Empty, OnTitleChanged));
+
+        public string Title
+        {
+            get => (string)GetValue(TitleProperty);
+            set => SetValue(TitleProperty, value);
+        }
+
+        public FullscreenSizeMode SizeMode { get; set; } = FullscreenSizeMode.Fullscreen;
+
+        public FrameworkElement HostedContent
+        {
+            get => ContentHost.Content as FrameworkElement;
+            set => ContentHost.Content = value;
+        }
+
+        public FullscreenOverlayContainer()
+        {
+            InitializeComponent();
+            CloseButton.Click += CloseButton_Click;
+            Loaded += OnLoaded;
+        }
+
+        public FullscreenOverlayContainer(string title, FrameworkElement content, FullscreenSizeMode sizeMode)
+            : this()
+        {
+            Title = title;
+            SizeMode = sizeMode;
+            HostedContent = content;
+        }
+
+        public void UpdatePanelSize()
+        {
+            var parent = Window.GetWindow(this);
+            double availWidth = parent?.ActualWidth > 0 ? parent.ActualWidth : SystemParameters.PrimaryScreenWidth;
+            double availHeight = parent?.ActualHeight > 0 ? parent.ActualHeight : SystemParameters.PrimaryScreenHeight;
+
+            if (SizeMode == FullscreenSizeMode.Dialog)
+            {
+                ContentPanel.MaxWidth = Math.Min(640, availWidth * 0.9);
+                ContentPanel.MaxHeight = Math.Min(400, availHeight * 0.9);
+            }
+            else
+            {
+                ContentPanel.MaxWidth = availWidth * 0.92;
+                ContentPanel.MaxHeight = availHeight * 0.92;
+            }
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            UpdatePanelSize();
+
+            if (HostedContent != null)
+            {
+                var focusTarget = FindFirstFocusable(HostedContent);
+                if (focusTarget != null)
+                {
+                    FocusManager.SetFocusedElement(this, focusTarget);
+                    Keyboard.Focus(focusTarget);
+                }
+            }
+        }
+
+        private void CloseButton_Click(object sender, RoutedEventArgs e)
+        {
+            var window = Window.GetWindow(this);
+            window?.Close();
+        }
+
+        private static void OnTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var container = (FullscreenOverlayContainer)d;
+            container.TitleText.Text = e.NewValue as string ?? string.Empty;
+        }
+
+        private static UIElement FindFirstFocusable(DependencyObject root)
+        {
+            int count = VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < count; i++)
+            {
+                var child = VisualTreeHelper.GetChild(root, i);
+                if (child is UIElement element && element.Focusable && element.IsEnabled)
+                {
+                    return element;
+                }
+
+                var nested = FindFirstFocusable(child);
+                if (nested != null)
+                {
+                    return nested;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/source/Views/Helpers/FullscreenOverlayContainer.xaml.cs
+++ b/source/Views/Helpers/FullscreenOverlayContainer.xaml.cs
@@ -94,7 +94,15 @@ namespace PlayniteAchievements.Views.Helpers
         private static void OnTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var container = (FullscreenOverlayContainer)d;
-            container.TitleText.Text = e.NewValue as string ?? string.Empty;
+            var title = e.NewValue as string ?? string.Empty;
+            var hasTitle = !string.IsNullOrWhiteSpace(title);
+            container.TitleText.Text = title;
+            container.TitleBar.Visibility = hasTitle
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+            container.CloseButton.Visibility = hasTitle
+                ? Visibility.Visible
+                : Visibility.Collapsed;
         }
 
         private static UIElement FindFirstFocusable(DependencyObject root)

--- a/source/Views/Helpers/PlayniteUiProvider.cs
+++ b/source/Views/Helpers/PlayniteUiProvider.cs
@@ -25,7 +25,7 @@ namespace PlayniteAchievements.Views.Helpers
             }
         }
 
-        public static Window CreateExtensionWindow(string Title, UserControl ViewExtension, WindowOptions windowOptions = null)
+        public static Window CreateExtensionWindow(string Title, UserControl ViewExtension, WindowOptions windowOptions = null, bool isFullscreen = false)
         {
             if (windowOptions == null)
             {
@@ -35,6 +35,11 @@ namespace PlayniteAchievements.Views.Helpers
                     ShowMaximizeButton = false,
                     ShowCloseButton = true
                 };
+            }
+
+            if (isFullscreen)
+            {
+                return CreateFullscreenWindow(Title, ViewExtension, windowOptions);
             }
 
             Window windowExtension = API.Instance.Dialogs.CreateWindow(windowOptions);
@@ -69,6 +74,52 @@ namespace PlayniteAchievements.Views.Helpers
             windowExtension.PreviewKeyDown += new KeyEventHandler(HandleEsc);
 
             return windowExtension;
+        }
+
+        private static Window CreateFullscreenWindow(string title, UserControl content, WindowOptions windowOptions)
+        {
+            var fsOptions = new WindowCreationOptions
+            {
+                ShowMinimizeButton = false,
+                ShowMaximizeButton = false,
+                ShowCloseButton = false
+            };
+
+            Window window = API.Instance.Dialogs.CreateWindow(fsOptions);
+
+            window.Title = title;
+            window.ShowInTaskbar = false;
+            window.WindowStyle = WindowStyle.None;
+            window.ResizeMode = ResizeMode.NoResize;
+
+            var parent = API.Instance.Dialogs.GetCurrentAppWindow();
+            if (parent != null)
+            {
+                window.Owner = parent;
+            }
+            window.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+
+            window.Height = parent != null && parent.Height > 0 ? parent.Height : SystemParameters.PrimaryScreenHeight;
+            window.Width = parent != null && parent.Width > 0 ? parent.Width : SystemParameters.PrimaryScreenWidth;
+
+            // Merge fullscreen resource fallbacks so desktop-only DynamicResource keys resolve.
+            window.Resources.MergedDictionaries.Add(
+                new ResourceDictionary
+                {
+                    Source = new Uri("/PlayniteAchievements;component/Resources/FullscreenResources.xaml", UriKind.Relative)
+                });
+
+            // Determine sizing mode based on the content type.
+            var sizeMode = content is RefreshProgressControl
+                ? FullscreenSizeMode.Dialog
+                : FullscreenSizeMode.Fullscreen;
+
+            var overlay = new FullscreenOverlayContainer(title, content, sizeMode);
+            window.Content = overlay;
+
+            window.PreviewKeyDown += new KeyEventHandler(HandleEsc);
+
+            return window;
         }
     }
 

--- a/source/Views/SettingsControl.xaml
+++ b/source/Views/SettingsControl.xaml
@@ -1029,7 +1029,7 @@
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto"/>
-                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
                                                 <ColumnDefinition Width="Auto"/>
                                             </Grid.ColumnDefinitions>
                                             <TextBlock Grid.Column="0"
@@ -1043,26 +1043,24 @@
                                                 <ComboBoxItem Content="{DynamicResource LOCPlayAch_Common_UnlockTime}" Tag="{x:Static settings:CompactListSortMode.UnlockTime}"/>
                                                 <ComboBoxItem Content="{DynamicResource LOCPlayAch_Column_Rarity}" Tag="{x:Static settings:CompactListSortMode.Rarity}"/>
                                             </ComboBox>
-                                            <CheckBox Grid.Column="2"
-                                                      IsChecked="{Binding Persisted.CompactListSortDescending, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                      ToolTip="{DynamicResource LOCPlayAch_Settings_SortDirection_Tooltip}"
-                                                      Margin="4,0,0,0"
-                                                      VerticalAlignment="Center">
-                                                <CheckBox.Content>
-                                                    <TextBlock FontFamily="{DynamicResource CommonFont}" FontSize="14">
-                                                        <TextBlock.Style>
-                                                            <Style TargetType="TextBlock">
-                                                                <Setter Property="Text" Value="&#xea65;"/>
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding Persisted.CompactListSortDescending}" Value="True">
-                                                                        <Setter Property="Text" Value="&#xea66;"/>
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </TextBlock.Style>
-                                                    </TextBlock>
-                                                </CheckBox.Content>
-                                            </CheckBox>
+                                            <Button Grid.Column="2"
+                                                    ToolTip="{DynamicResource LOCPlayAch_Settings_SortDirection_Tooltip}"
+                                                    Margin="4,0,0,0"
+                                                    VerticalAlignment="Center"
+                                                    Click="ToggleCompactListSortDescending">
+                                                <TextBlock FontFamily="{DynamicResource CommonFont}" FontSize="18">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Text" Value="&#xea65;"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding Persisted.CompactListSortDescending}" Value="True">
+                                                                    <Setter Property="Text" Value="&#xea66;"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </Button>
                                         </Grid>
                                     </StackPanel>
                                 </Border>
@@ -1143,7 +1141,7 @@
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto"/>
-                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
                                                 <ColumnDefinition Width="Auto"/>
                                             </Grid.ColumnDefinitions>
                                             <TextBlock Grid.Column="0"
@@ -1157,26 +1155,24 @@
                                                 <ComboBoxItem Content="{DynamicResource LOCPlayAch_Common_UnlockTime}" Tag="{x:Static settings:CompactListSortMode.UnlockTime}"/>
                                                 <ComboBoxItem Content="{DynamicResource LOCPlayAch_Column_Rarity}" Tag="{x:Static settings:CompactListSortMode.Rarity}"/>
                                             </ComboBox>
-                                            <CheckBox Grid.Column="2"
-                                                      IsChecked="{Binding Persisted.CompactUnlockedListSortDescending, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                      ToolTip="{DynamicResource LOCPlayAch_Settings_SortDirection_Tooltip}"
-                                                      Margin="4,0,0,0"
-                                                      VerticalAlignment="Center">
-                                                <CheckBox.Content>
-                                                    <TextBlock FontFamily="{DynamicResource CommonFont}" FontSize="14">
-                                                        <TextBlock.Style>
-                                                            <Style TargetType="TextBlock">
-                                                                <Setter Property="Text" Value="&#xea65;"/>
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding Persisted.CompactUnlockedListSortDescending}" Value="True">
-                                                                        <Setter Property="Text" Value="&#xea66;"/>
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </TextBlock.Style>
-                                                    </TextBlock>
-                                                </CheckBox.Content>
-                                            </CheckBox>
+                                            <Button Grid.Column="2"
+                                                    ToolTip="{DynamicResource LOCPlayAch_Settings_SortDirection_Tooltip}"
+                                                    Margin="4,0,0,0"
+                                                    VerticalAlignment="Center"
+                                                    Click="ToggleCompactUnlockedListSortDescending">
+                                                <TextBlock FontFamily="{DynamicResource CommonFont}" FontSize="18">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Text" Value="&#xea65;"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding Persisted.CompactUnlockedListSortDescending}" Value="True">
+                                                                    <Setter Property="Text" Value="&#xea66;"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </Button>
                                         </Grid>
                                     </StackPanel>
                                 </Border>
@@ -1215,7 +1211,7 @@
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto"/>
-                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
                                                 <ColumnDefinition Width="Auto"/>
                                             </Grid.ColumnDefinitions>
                                             <TextBlock Grid.Column="0"
@@ -1229,26 +1225,24 @@
                                                 <ComboBoxItem Content="{DynamicResource LOCPlayAch_Common_UnlockTime}" Tag="{x:Static settings:CompactListSortMode.UnlockTime}"/>
                                                 <ComboBoxItem Content="{DynamicResource LOCPlayAch_Column_Rarity}" Tag="{x:Static settings:CompactListSortMode.Rarity}"/>
                                             </ComboBox>
-                                            <CheckBox Grid.Column="2"
-                                                      IsChecked="{Binding Persisted.CompactLockedListSortDescending, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                      ToolTip="{DynamicResource LOCPlayAch_Settings_SortDirection_Tooltip}"
-                                                      Margin="4,0,0,0"
-                                                      VerticalAlignment="Center">
-                                                <CheckBox.Content>
-                                                    <TextBlock FontFamily="{DynamicResource CommonFont}" FontSize="14">
-                                                        <TextBlock.Style>
-                                                            <Style TargetType="TextBlock">
-                                                                <Setter Property="Text" Value="&#xea65;"/>
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding Persisted.CompactLockedListSortDescending}" Value="True">
-                                                                        <Setter Property="Text" Value="&#xea66;"/>
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </TextBlock.Style>
-                                                    </TextBlock>
-                                                </CheckBox.Content>
-                                            </CheckBox>
+                                            <Button Grid.Column="2"
+                                                    ToolTip="{DynamicResource LOCPlayAch_Settings_SortDirection_Tooltip}"
+                                                    Margin="4,0,0,0"
+                                                    VerticalAlignment="Center"
+                                                    Click="ToggleCompactLockedListSortDescending">
+                                                <TextBlock FontFamily="{DynamicResource CommonFont}" FontSize="18">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Text" Value="&#xea65;"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding Persisted.CompactLockedListSortDescending}" Value="True">
+                                                                    <Setter Property="Text" Value="&#xea66;"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </Button>
                                         </Grid>
                                     </StackPanel>
                                 </Border>

--- a/source/Views/SettingsControl.xaml.cs
+++ b/source/Views/SettingsControl.xaml.cs
@@ -1200,6 +1200,37 @@ namespace PlayniteAchievements.Views
         }
 
         // -----------------------------
+        // Compact list sort direction toggles
+        // -----------------------------
+
+        private void ToggleCompactListSortDescending(object sender, RoutedEventArgs e)
+        {
+            var persisted = _settingsViewModel?.Settings?.Persisted;
+            if (persisted != null)
+            {
+                persisted.CompactListSortDescending = !persisted.CompactListSortDescending;
+            }
+        }
+
+        private void ToggleCompactUnlockedListSortDescending(object sender, RoutedEventArgs e)
+        {
+            var persisted = _settingsViewModel?.Settings?.Persisted;
+            if (persisted != null)
+            {
+                persisted.CompactUnlockedListSortDescending = !persisted.CompactUnlockedListSortDescending;
+            }
+        }
+
+        private void ToggleCompactLockedListSortDescending(object sender, RoutedEventArgs e)
+        {
+            var persisted = _settingsViewModel?.Settings?.Persisted;
+            if (persisted != null)
+            {
+                persisted.CompactLockedListSortDescending = !persisted.CompactLockedListSortDescending;
+            }
+        }
+
+        // -----------------------------
         // Tagging Methods
         // -----------------------------
 


### PR DESCRIPTION
Makes the achievements overlay work in Playnite's fullscreen mode. Before this it would break or show the desktop overlay on top of the fullscreen UI.

- FullscreenOverlayContainer for the window chrome in fullscreen
- FullscreenResources.xaml with dark-theme styles so controls are visible on the dark fullscreen background
- Fullscreen window creation path in PlayniteUiProvider
- PluginWindowService detects fullscreen mode and opens/closes windows correctly
- Achievements menu item that only appears in fullscreen mode
- Overlay chrome hides when content has its own header